### PR TITLE
Update GHCR image references to hyperlight-dev org

### DIFF
--- a/examples/dotnet-nativeaot/Justfile
+++ b/examples/dotnet-nativeaot/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/dotnet-nativeaot-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
 memory      := "16Mi"
 image       := "dotnet-nativeaot-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/dotnet-nativeaot-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/dotnet-nativeaot-kernel:latest"
 
 # Run the example
 run:

--- a/examples/dotnet/Justfile
+++ b/examples/dotnet/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/dotnet-hyperlight_hyperlight-x86_64"
 initrd      := "dotnet-initrd.cpio"
 memory      := "16Mi"
 image       := "dotnet-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/dotnet-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/dotnet-kernel:latest"
 
 # Run the example
 run:

--- a/examples/go/Justfile
+++ b/examples/go/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/go-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
 memory      := "16Mi"
 image       := "go-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/go-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/go-kernel:latest"
 
 # Run the example
 run:

--- a/examples/helloworld-c/Justfile
+++ b/examples/helloworld-c/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/helloworld-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
 memory      := "4Mi"
 image       := "helloworld-c-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/helloworld-c-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/helloworld-c-kernel:latest"
 
 # Run the example
 run:

--- a/examples/hostfs-posix-c/Justfile
+++ b/examples/hostfs-posix-c/Justfile
@@ -10,7 +10,7 @@ kernel      := ".unikraft/build/hostfs-posix-c-hyperlight_hyperlight-x86_64"
 initrd      := "hostfs-posix-c-initrd.cpio"
 memory      := "16Mi"
 image       := "hostfs-posix-c-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/hostfs-posix-c-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/hostfs-posix-c-kernel:latest"
 mount_dir   := "./work"
 
 [unix]

--- a/examples/hostfs-posix-py/Dockerfile
+++ b/examples/hostfs-posix-py/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/python-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/python-base:latest
 FROM ${BASE} AS rootfs
 COPY hostfs_demo.py /hostfs_demo.py
 

--- a/examples/hostfs-posix-py/Justfile
+++ b/examples/hostfs-posix-py/Justfile
@@ -10,7 +10,7 @@ kernel      := ".unikraft/build/hostfs-posix-py-hyperlight_hyperlight-x86_64"
 initrd      := "hostfs-posix-py-initrd.cpio"
 memory      := "96Mi"
 image       := "hostfs-posix-py-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/hostfs-posix-py-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/hostfs-posix-py-kernel:latest"
 mount_dir   := "./work"
 
 [unix]

--- a/examples/nodejs/Dockerfile
+++ b/examples/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/nodejs-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/nodejs-base:latest
 FROM ${BASE} AS rootfs
 COPY hello.js /app/hello.js
 

--- a/examples/nodejs/Justfile
+++ b/examples/nodejs/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/nodejs-hyperlight_hyperlight-x86_64"
 initrd      := "node-initrd.cpio"
 memory      := "512Mi"
 image       := "nodejs-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/nodejs-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/nodejs-kernel:latest"
 
 # Run the example
 run:

--- a/examples/powershell/Dockerfile
+++ b/examples/powershell/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/powershell-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/powershell-base:latest
 FROM ${BASE} AS rootfs
 COPY hello.ps1 /scripts/hello.ps1
 

--- a/examples/powershell/Justfile
+++ b/examples/powershell/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/powershell-hyperlight_hyperlight-x86_64"
 initrd      := "powershell-initrd.cpio"
 memory      := "1Gi"
 image       := "powershell-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/powershell-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/powershell-kernel:latest"
 
 # Run the example
 run:

--- a/examples/python-agent-driver/Dockerfile
+++ b/examples/python-agent-driver/Dockerfile
@@ -6,7 +6,7 @@
 # installs an FC-aware dispatch callback that handles every
 # subsequent host->guest call without re-running main().
 
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/python-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/python-base:latest
 
 # Stage 1: Python deps (same as python-agent).
 FROM python:3.12-slim AS deps

--- a/examples/python-agent/Dockerfile
+++ b/examples/python-agent/Dockerfile
@@ -8,7 +8,7 @@
 
 # BASE is resolved pre-FROM so the classic (non-BuildKit) docker
 # frontend used by DOCKER_BUILDKIT=0 handles the substitution.
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/python-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/python-base:latest
 
 # Stage 1: resolve + install pip deps into a target dir, then trim
 # everything the guest doesn't need (pip/setuptools/wheel metadata,

--- a/examples/python-agent/Justfile
+++ b/examples/python-agent/Justfile
@@ -18,7 +18,7 @@ kernel      := ".unikraft/build/python-agent-hyperlight_hyperlight-x86_64"
 initrd      := "python-agent-initrd.cpio"
 memory      := "1Gi"
 image       := "python-agent-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/python-agent-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-kernel:latest"
 mount_dir   := "./work"
 
 [unix]

--- a/examples/python-tools/Dockerfile
+++ b/examples/python-tools/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/python-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/python-base:latest
 FROM ${BASE} AS rootfs
 COPY test_tools.py /test_tools.py
 # hyperlight.py is the guest-side SDK test_tools.py imports. Python's

--- a/examples/python-tools/Justfile
+++ b/examples/python-tools/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/python-tools-hyperlight_hyperlight-x86_64"
 initrd      := "initrd.cpio"
 memory      := "96Mi"
 image       := "python-tools-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/python-tools-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-tools-kernel:latest"
 
 # Run the example
 run:

--- a/examples/python/Dockerfile
+++ b/examples/python/Dockerfile
@@ -8,7 +8,7 @@
 # Then:
 #   docker build --build-arg BASE=python-base --target cpio -t python-cpio .
 
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/python-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/python-base:latest
 FROM ${BASE} AS rootfs
 COPY hello.py /hello.py
 

--- a/examples/python/Justfile
+++ b/examples/python/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/python-hyperlight_hyperlight-x86_64"
 initrd      := "initrd.cpio"
 memory      := "96Mi"
 image       := "python-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/python-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-kernel:latest"
 
 # Run the example
 run:

--- a/examples/rust/Justfile
+++ b/examples/rust/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/rust-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
 memory      := "16Mi"
 image       := "rust-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/rust-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/rust-kernel:latest"
 
 # Run the example
 run:

--- a/examples/shell/Dockerfile
+++ b/examples/shell/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=ghcr.io/danbugs/hyperlight-unikraft/shell-base:latest
+ARG BASE=ghcr.io/hyperlight-dev/hyperlight-unikraft/shell-base:latest
 FROM ${BASE} AS rootfs
 COPY demo.sh /demo.sh
 

--- a/examples/shell/Justfile
+++ b/examples/shell/Justfile
@@ -13,7 +13,7 @@ kernel      := ".unikraft/build/shell-hyperlight_hyperlight-x86_64"
 initrd      := "initrd.cpio"
 memory      := "16Mi"
 image       := "shell-hyperlight"
-ghcr_kernel := "ghcr.io/danbugs/hyperlight-unikraft/shell-kernel:latest"
+ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/shell-kernel:latest"
 
 # Run the example
 run:

--- a/host/src/pyhl.rs
+++ b/host/src/pyhl.rs
@@ -344,9 +344,9 @@ pub fn discover_source_artifacts(dir: &Path) -> Result<(PathBuf, PathBuf)> {
 /// Both images are FROM-scratch payloads: kernel image has a single /kernel,
 /// initrd image has a single /initrd.cpio.
 pub const GHCR_KERNEL_IMAGE: &str =
-    "ghcr.io/danbugs/hyperlight-unikraft/python-agent-driver-kernel:latest";
+    "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-kernel:latest";
 pub const GHCR_INITRD_IMAGE: &str =
-    "ghcr.io/danbugs/hyperlight-unikraft/python-agent-driver-initrd:latest";
+    "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-agent-driver-initrd:latest";
 
 /// Pull a single file out of an OCI image hosted on GHCR. Uses whichever
 /// of `docker` / `podman` is on `$PATH`. The published images are


### PR DESCRIPTION
## Summary

- Updates all `ghcr.io/danbugs/hyperlight-unikraft` references to `ghcr.io/hyperlight-dev/hyperlight-unikraft` across Justfiles (14), Dockerfiles (9), and `host/src/pyhl.rs` (2)

Closes #2