### PR TITLE
host: switch snapshot mapping to PAGE_READONLY (PR #1373)

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,9 +114,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -172,6 +160,26 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "cc"
@@ -506,8 +514,8 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hyperlight-common"
-version = "0.14.0"
-source = "git+https://github.com/danbugs/hyperlight?branch=snapshot-to-disk#c7441476c338ee3aa1af88083036e0407864d8a0"
+version = "0.15.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?branch=disk_snapshot_copy#621cc03beadae3d9158e72d07d3d156abf2b21fd"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -520,13 +528,14 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.14.0"
-source = "git+https://github.com/danbugs/hyperlight?branch=snapshot-to-disk#c7441476c338ee3aa1af88083036e0407864d8a0"
+version = "0.15.0"
+source = "git+https://github.com/hyperlight-dev/hyperlight?branch=disk_snapshot_copy#621cc03beadae3d9158e72d07d3d156abf2b21fd"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
  "blake3",
  "built",
+ "bytemuck",
  "cfg-if",
  "cfg_aliases",
  "crossbeam-channel",
@@ -782,9 +791,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -858,12 +867,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -1055,6 +1064,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "redox_users"
@@ -1420,9 +1438,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -27,13 +27,9 @@ name = "pyhl"
 path = "src/bin/pyhl.rs"
 
 [dependencies]
-# Point at danbugs/hyperlight snapshot-to-disk, which is upstream main
-# (the map_file_cow unaligned fix landed there) plus a squashed port of
 # hyperlight-dev/hyperlight#1373 — Ludvig's Snapshot::to_file/from_file
-# feature. We use it to persist a warmed-up sandbox on `pyhl setup` and
-# load it directly on every `pyhl run`, avoiding evolve + warmup per
-# invocation.
-hyperlight-host = { git = "https://github.com/danbugs/hyperlight", branch = "snapshot-to-disk", features = ["executable_heap", "hw-interrupts"] }
+# Uses PAGE_READONLY mapping (no host commit charge per VM).
+hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", branch = "disk_snapshot_copy", features = ["executable_heap", "hw-interrupts"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 memmap2 = "0.9"

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -64,7 +64,7 @@ use hyperlight_host::func::Registerable;
 use hyperlight_host::sandbox::snapshot::Snapshot;
 use hyperlight_host::sandbox::uninitialized::GuestEnvironment;
 use hyperlight_host::sandbox::SandboxConfiguration;
-use hyperlight_host::{GuestBinary, MultiUseSandbox, UninitializedSandbox};
+use hyperlight_host::{GuestBinary, HostFunctions, MultiUseSandbox, UninitializedSandbox};
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
@@ -1402,21 +1402,25 @@ impl Sandbox {
     pub fn from_snapshot_file_with<P: AsRef<Path>>(path: P, preopens: &[Preopen]) -> Result<Self> {
         let loaded = Snapshot::from_file_unchecked(path.as_ref())?;
         let arc = Arc::new(loaded);
-        let mut inner = MultiUseSandbox::from_snapshot(arc.clone())?;
 
-        // Wire up the fs_* tool handlers against the caller's preopens.
-        // The snapshot was warmed up with hostfs already mounted, so the
-        // guest will route fs_* calls through __dispatch → the FsRouter
-        // we install here.
+        let mut host_funcs = HostFunctions::default();
         if !preopens.is_empty() {
             if let Some(tools) = build_tools(None, preopens)? {
                 let tools = Arc::new(tools);
                 let tools_ref = tools.clone();
-                inner.register_host_function("__dispatch", move |payload: Vec<u8>| -> Vec<u8> {
-                    tools_ref.dispatch(&payload)
-                })?;
+                host_funcs.register_host_function(
+                    "__dispatch",
+                    move |payload: Vec<u8>| -> Vec<u8> { tools_ref.dispatch(&payload) },
+                )?;
             }
+        } else {
+            host_funcs.register_host_function(
+                "__dispatch",
+                |_payload: Vec<u8>| -> Vec<u8> { Vec::new() },
+            )?;
         }
+
+        let inner = MultiUseSandbox::from_snapshot(arc.clone(), host_funcs, None)?;
 
         Ok(Self {
             inner,

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1408,16 +1408,15 @@ impl Sandbox {
             if let Some(tools) = build_tools(None, preopens)? {
                 let tools = Arc::new(tools);
                 let tools_ref = tools.clone();
-                host_funcs.register_host_function(
-                    "__dispatch",
-                    move |payload: Vec<u8>| -> Vec<u8> { tools_ref.dispatch(&payload) },
-                )?;
+                host_funcs
+                    .register_host_function("__dispatch", move |payload: Vec<u8>| -> Vec<u8> {
+                        tools_ref.dispatch(&payload)
+                    })?;
             }
         } else {
-            host_funcs.register_host_function(
-                "__dispatch",
-                |_payload: Vec<u8>| -> Vec<u8> { Vec::new() },
-            )?;
+            host_funcs.register_host_function("__dispatch", |_payload: Vec<u8>| -> Vec<u8> {
+                Vec::new()
+            })?;
         }
 
         let inner = MultiUseSandbox::from_snapshot(arc.clone(), host_funcs, None)?;


### PR DESCRIPTION
## Summary

- Switches the hyperlight-host dependency from the `snapshot-to-disk` branch (which used `PAGE_WRITECOPY` / `FILE_MAP_COPY` from PR #1391) to `disk_snapshot_copy` (PR #1373's `PAGE_READONLY` / `FILE_MAP_READ` approach)
- Adapts `from_snapshot_file_with` to the updated `MultiUseSandbox::from_snapshot` API which now requires `HostFunctions` and an optional `SandboxConfiguration`

This eliminates the Windows commit-charge problem where each VM reserved ~2.5 GB of virtual commit for the CoW mapping. With `PAGE_READONLY`, CoW is handled at the hypervisor level (SLAT/EPT) rather than the host OS level, so Windows does not reserve commit charge per VM.

**Before:** ~2535 MB commit per VM, max 5-6 VMs on 16 GB machine
**After:** 6 MB private per VM, 10 VMs verified at 59 MB total