### PR TITLE
Use upstream unikraft/app-elfloader plat-hyperlight branches

### DIFF
--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -106,8 +106,8 @@ jobs:
             UK_BRANCH=$(grep 'version:' kraft.yaml | head -1 | awk '{print $2}')
             mkdir -p .unikraft/apps .unikraft/libs
             rm -rf .unikraft/unikraft .unikraft/apps/elfloader
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/unikraft.git .unikraft/unikraft
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/app-elfloader.git .unikraft/apps/elfloader
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/unikraft.git .unikraft/unikraft
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/app-elfloader.git .unikraft/apps/elfloader
             git clone --branch staging --depth 1 https://github.com/unikraft/lib-libelf.git .unikraft/libs/libelf
             rm -rf .unikraft/build
             kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -108,8 +108,8 @@ jobs:
             UK_BRANCH=$(grep -E '^  version:' kraft.yaml | head -1 | awk '{print $2}')
             mkdir -p .unikraft/apps .unikraft/libs
             rm -rf .unikraft/unikraft .unikraft/apps/elfloader .unikraft/libs/libelf .unikraft/build
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/unikraft.git .unikraft/unikraft
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/app-elfloader.git .unikraft/apps/elfloader
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/unikraft.git .unikraft/unikraft
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/app-elfloader.git .unikraft/apps/elfloader
             git clone --branch staging --depth 1 https://github.com/unikraft/lib-libelf.git .unikraft/libs/libelf
             kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64
           fi
@@ -285,8 +285,8 @@ jobs:
             UK_BRANCH=$(grep -E '^  version:' kraft.yaml | head -1 | awk '{print $2}')
             mkdir -p .unikraft/apps .unikraft/libs
             rm -rf .unikraft/unikraft .unikraft/apps/elfloader .unikraft/libs/libelf .unikraft/build
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/unikraft.git .unikraft/unikraft
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/app-elfloader.git .unikraft/apps/elfloader
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/unikraft.git .unikraft/unikraft
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/app-elfloader.git .unikraft/apps/elfloader
             git clone --branch staging --depth 1 https://github.com/unikraft/lib-libelf.git .unikraft/libs/libelf
             kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64
           fi
@@ -418,8 +418,8 @@ jobs:
             UK_BRANCH=$(grep -E '^  version:' kraft.yaml | head -1 | awk '{print $2}')
             mkdir -p .unikraft/apps .unikraft/libs
             rm -rf .unikraft/unikraft .unikraft/apps/elfloader .unikraft/libs/libelf .unikraft/build
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/unikraft.git .unikraft/unikraft
-            git clone --branch $UK_BRANCH --depth 1 https://github.com/danbugs/app-elfloader.git .unikraft/apps/elfloader
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/unikraft.git .unikraft/unikraft
+            git clone --branch $UK_BRANCH --depth 1 https://github.com/unikraft/app-elfloader.git .unikraft/apps/elfloader
             git clone --branch staging --depth 1 https://github.com/unikraft/lib-libelf.git .unikraft/libs/libelf
             kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64
           fi

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Every path the guest sends is resolved relative to `HOST_DIR` and any
 escape (via `..` or symlinks) is rejected host-side.
 
 Known limitation: `opendir`/`readdir` don't work yet (see
-[lib/hostfs/README.md](https://github.com/unikraft/unikraft/blob/hyperlight-platform/lib/hostfs/README.md)). Stat and enumerate known paths instead.
+[lib/hostfs/README.md](https://github.com/unikraft/unikraft/blob/plat-hyperlight/lib/hostfs/README.md)). Stat and enumerate known paths instead.
 
 ### Running ad-hoc code (no initrd rebuild)
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 cargo install just
 
 # 2. kraft-hyperlight (builds Unikraft kernels)
-git clone --branch hyperlight-platform https://github.com/unikraft/kraftkit.git
+git clone --branch hyperlight-platform https://github.com/danbugs/kraftkit.git
 cd kraftkit && go build -o kraft-hyperlight ./cmd/kraft
 sudo mv kraft-hyperlight /usr/local/bin/ && cd ..
 

--- a/demos/pptx-gen/kraft.yaml
+++ b/demos/pptx-gen/kraft.yaml
@@ -4,8 +4,8 @@ specification: '0.6'
 name: python-pptx-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -61,8 +61,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/dotnet-nativeaot/kraft.yaml
+++ b/examples/dotnet-nativeaot/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: dotnet-nativeaot-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'
@@ -53,8 +53,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/dotnet/kraft.yaml
+++ b/examples/dotnet/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: dotnet-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -78,8 +78,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/go/kraft.yaml
+++ b/examples/go/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: go-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -61,8 +61,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/helloworld-c/kraft.yaml
+++ b/examples/helloworld-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: helloworld-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'
@@ -52,8 +52,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/hostfs-posix-c/kraft.yaml
+++ b/examples/hostfs-posix-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: hostfs-posix-c-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -68,8 +68,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/hostfs-posix-py/kraft.yaml
+++ b/examples/hostfs-posix-py/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: hostfs-posix-py-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -73,8 +73,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/multifn-c/kraft.yaml
+++ b/examples/multifn-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: multifn-c-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'
@@ -46,8 +46,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/nodejs/kraft.yaml
+++ b/examples/nodejs/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: nodejs-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -74,8 +74,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/powershell/kraft.yaml
+++ b/examples/powershell/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: powershell-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -89,8 +89,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/python-agent-driver/kraft.yaml
+++ b/examples/python-agent-driver/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: python-agent-driver-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'
@@ -71,8 +71,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/python-agent/kraft.yaml
+++ b/examples/python-agent/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: python-agent-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -85,8 +85,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/python-tools/kraft.yaml
+++ b/examples/python-tools/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: python-tools-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -63,8 +63,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/python/kraft.yaml
+++ b/examples/python/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: python-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -64,8 +64,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/rust/kraft.yaml
+++ b/examples/rust/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: rust-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -59,8 +59,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging

--- a/examples/shell/kraft.yaml
+++ b/examples/shell/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: shell-hyperlight
 
 unikraft:
-  source: https://github.com/danbugs/unikraft.git
-  version: hyperlight-platform
+  source: https://github.com/unikraft/unikraft.git
+  version: plat-hyperlight
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'
@@ -63,8 +63,8 @@ unikraft:
 
 libraries:
   app-elfloader:
-    source: https://github.com/danbugs/app-elfloader.git
-    version: hyperlight-platform
+    source: https://github.com/unikraft/app-elfloader.git
+    version: plat-hyperlight
   libelf:
     source: https://github.com/unikraft/lib-libelf.git
     version: staging


### PR DESCRIPTION
## Summary

- Switch all kraft.yaml files (16 examples + 1 demo) from `danbugs/{unikraft,app-elfloader}` to `unikraft/{unikraft,app-elfloader}` on the `plat-hyperlight` branch
- Update CI workflow fallback clones in `publish-examples.yml` and `test-examples.yml` to use the upstream repos
- Update README hostfs link to point to `plat-hyperlight` branch
- Fix README kraftkit clone URL to use `danbugs/kraftkit` (upstream PR still pending)

Kraftkit references are unchanged — the upstream PR is still pending.

Closes #1. Closes #3.