### PR TITLE
fix: sparsify message reports resulting disk size instead of amount removed

### DIFF
--- a/examples/dotnet-nativeaot/HelloNativeAot.csproj
+++ b/examples/dotnet-nativeaot/HelloNativeAot.csproj
@@ -7,6 +7,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" Version="9.0.15" />
+    <PackageReference Include="runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" Version="9.0.16" />
   </ItemGroup>
 </Project>

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1578,7 +1578,7 @@ fn sparsify_snapshot(path: &Path) -> Result<()> {
     drop(mmap);
 
     if punched > 0 {
-        let disk_mib = (len as u64 - punched * PAGE as u64) / 1024 / 1024;
+        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
         eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
     }
 
@@ -1666,7 +1666,7 @@ fn sparsify_snapshot(path: &Path) -> Result<()> {
     drop(mmap);
 
     if punched > 0 {
-        let disk_mib = (len as u64 - punched * PAGE as u64) / 1024 / 1024;
+        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
         eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
     }
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1578,11 +1578,8 @@ fn sparsify_snapshot(path: &Path) -> Result<()> {
     drop(mmap);
 
     if punched > 0 {
-        eprintln!(
-            "  sparsified: punched {} zero pages ({} MiB saved on disk)",
-            punched,
-            punched * 4 / 1024
-        );
+        let disk_mib = (len as u64 - punched * PAGE as u64) / 1024 / 1024;
+        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
     }
 
     Ok(())
@@ -1669,11 +1666,8 @@ fn sparsify_snapshot(path: &Path) -> Result<()> {
     drop(mmap);
 
     if punched > 0 {
-        eprintln!(
-            "  sparsified: punched {} zero pages ({} MiB saved on disk)",
-            punched,
-            punched * 4 / 1024
-        );
+        let disk_mib = (len as u64 - punched * PAGE as u64) / 1024 / 1024;
+        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Changes the sparsification log message from `"1368 MiB saved on disk"` (confusing — reads like the file IS 1368 MiB) to `"648 MiB on disk (punched 350246 zero pages)"` (reports the actual resulting size)
- Fixes both the Linux and Windows code paths
- Also bumps `runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler` from 9.0.15 to 9.0.16 to fix dotnet-nativeaot CI build failure (upstream NuGet package version drift)