### PR TITLE
ci: add umbrella checks and smart path filtering

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -444,3 +444,18 @@ jobs:
           Write-Host "| Disk usage | ${diskMiB} MiB |"
           Write-Host ""
           Write-Host "::notice::snapshot: apparent=${apparentMiB}MiB disk=${diskMiB}MiB"
+
+  all-checks-passed:
+    if: always()
+    needs: [build-image, bench-linux, bench-windows]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          results=("${{ needs.build-image.result }}" "${{ needs.bench-linux.result }}" "${{ needs.bench-windows.result }}")
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "Job failed with result: $r"
+              exit 1
+            fi
+          done
+          echo "All checks passed"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -449,6 +449,7 @@ jobs:
     if: always()
     needs: [build-image, bench-linux, bench-windows]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           results=("${{ needs.build-image.result }}" "${{ needs.bench-linux.result }}" "${{ needs.bench-windows.result }}")

--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -71,3 +71,18 @@ jobs:
           # skip themselves if /dev/kvm isn't available.
           RUST_BACKTRACE: '1'
         run: cargo test --all-targets --locked
+
+  all-checks-passed:
+    if: always()
+    needs: [checks]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          results=("${{ needs.checks.result }}")
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "Job failed with result: $r"
+              exit 1
+            fi
+          done
+          echo "All checks passed"

--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -28,6 +28,8 @@ concurrency:
 jobs:
   checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 25
     defaults:
       run:

--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -78,6 +78,7 @@ jobs:
     if: always()
     needs: [checks]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           results=("${{ needs.checks.result }}")

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
+    paths:
+      - 'examples/**'
+      - 'runtimes/**'
+      - 'host/**'
+      - '.github/workflows/test-examples.yml'
   push:
     branches: [main]
     paths:
@@ -738,3 +743,18 @@ jobs:
             Write-Error "FAIL: expected >=5 pandas_ok lines, got $hits"
             exit 1
           }
+
+  all-checks-passed:
+    if: always()
+    needs: [build-example, runtime-test, package-images-for-windows, runtime-test-windows, pyhl-snapshot-test]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          results=("${{ needs.build-example.result }}" "${{ needs.runtime-test.result }}" "${{ needs.package-images-for-windows.result }}" "${{ needs.runtime-test-windows.result }}" "${{ needs.pyhl-snapshot-test.result }}")
+          for r in "${results[@]}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "Job failed with result: $r"
+              exit 1
+            fi
+          done
+          echo "All checks passed"

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -748,6 +748,7 @@ jobs:
     if: always()
     needs: [build-example, runtime-test, package-images-for-windows, runtime-test-windows, pyhl-snapshot-test]
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: |
           results=("${{ needs.build-example.result }}" "${{ needs.runtime-test.result }}" "${{ needs.package-images-for-windows.result }}" "${{ needs.runtime-test-windows.result }}" "${{ needs.pyhl-snapshot-test.result }}")


### PR DESCRIPTION
## Summary
- Adds `all-checks-passed` umbrella job to each workflow (`host-checks`, `benchmarks`, `test-examples`) for use as required status checks in branch protection / auto-merge
- Scopes `test-examples.yml` PR trigger to `examples/**`, `runtimes/**`, `host/**` paths so docs-only or unrelated changes skip the heavy build+test matrix
- Each umbrella job uses `if: always()` and validates all dependency jobs either succeeded or were skipped, so path-filtered runs still pass the gate