### PR TITLE
ci: always comment benchmark results on PRs + add trend links to README

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -296,7 +296,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: dev/bench/linux
           auto-push: ${{ github.event_name == 'push' }}
-          comment-on-alert: true
+          comment-always: true
           alert-threshold: '130%'
 
   # ------------------------------------------------------------------
@@ -499,7 +499,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           benchmark-data-dir-path: dev/bench/windows
           auto-push: ${{ github.event_name == 'push' }}
-          comment-on-alert: true
+          comment-always: true
           alert-threshold: '130%'
 
   all-checks-passed:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ This project enables running Linux applications (Python, Node.js, Go, Rust, C/C+
 - **Generic cmdline mechanism** - Pass arguments to any application via `-- arg1 arg2 ...`
 - **Fast cold start** - Hyperlight's lightweight design enables millisecond startup times
 
+### Benchmarks
+
+Performance and density benchmarks run on every push to `main` and on PRs. Historical trends are available at:
+
+- [Linux benchmarks](https://hyperlight-dev.github.io/hyperlight-unikraft/dev/bench/linux/)
+- [Windows benchmarks](https://hyperlight-dev.github.io/hyperlight-unikraft/dev/bench/windows/)
+
 ## Prerequisites
 
 Common on both Linux and Windows:


### PR DESCRIPTION
## Summary
- Changes `comment-on-alert` to `comment-always` so every PR gets a benchmark comparison comment (not just regressions)
- Adds links to the Linux and Windows benchmark trend charts in the README under a new Benchmarks section