### PR TITLE
ci: add Cargo and kraft-hyperlight caching

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -40,15 +40,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Go (for kraft-hyperlight)
-        run: |
-          curl -sL https://go.dev/dl/go1.25.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
-          echo "/usr/local/go/bin" >> $GITHUB_PATH
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+          cache: false
 
       - name: Install just
         uses: extractions/setup-just@v2
 
+      - name: Cache kraft-hyperlight
+        id: kraft-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/kraft-hyperlight
+          key: kraft-hyperlight-linux-${{ hashFiles('.github/workflows/benchmarks.yml') }}
+
       - name: Build kraft-hyperlight
+        if: steps.kraft-cache.outputs.cache-hit != 'true'
         run: |
           git clone --branch hyperlight-platform --depth 1 \
               https://github.com/danbugs/kraftkit.git /tmp/kraftkit
@@ -115,6 +123,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
 
       - name: Enable KVM permissions
         run: |
@@ -313,14 +325,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
+
       - name: Install pyhl
         shell: pwsh
         run: |
-          cargo install --git https://github.com/${{ github.repository }} `
-            --branch ${{ github.head_ref || github.ref_name }} `
-            hyperlight-unikraft-host `
-            --bin pyhl `
-            --locked --force
+          cd host
+          cargo build --release --bin pyhl
+          Copy-Item target\release\pyhl.exe $env:USERPROFILE\.cargo\bin\ -Force
 
       - name: Download prebuilt image
         uses: actions/download-artifact@v4

--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -37,6 +37,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
+
       - name: Install Rust components for pinned toolchain
         # The repo pins 1.89.0 via rust-toolchain.toml at the repo root.
         # cargo fmt / clippy use the pinned channel, so install their

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -88,11 +88,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+          cache: false
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
+
+      - name: Cache kraft-hyperlight
+        id: kraft-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/kraft-hyperlight
+          key: kraft-hyperlight-linux-${{ hashFiles('.github/workflows/publish-examples.yml') }}
+
       - name: Install tools
         run: |
-          # Install kraft-hyperlight
-          git clone --branch hyperlight-platform --depth 1 https://github.com/danbugs/kraftkit.git /tmp/kraftkit
-          cd /tmp/kraftkit && go build -o /usr/local/bin/kraft-hyperlight ./cmd/kraft
+          # Install kraft-hyperlight (if not cached)
+          if [ ! -f /usr/local/bin/kraft-hyperlight ]; then
+            git clone --branch hyperlight-platform --depth 1 https://github.com/danbugs/kraftkit.git /tmp/kraftkit
+            cd /tmp/kraftkit && go build -o /usr/local/bin/kraft-hyperlight ./cmd/kraft
+          fi
           # Install hyperlight-unikraft
           cd ${{ github.workspace }}/host && cargo build --release
           sudo cp target/release/hyperlight-unikraft /usr/local/bin/

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -68,15 +68,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Go (for kraft-hyperlight)
-        run: |
-          curl -sL https://go.dev/dl/go1.25.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
-          echo "/usr/local/go/bin" >> $GITHUB_PATH
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+          cache: false
 
       - name: Install just
         uses: extractions/setup-just@v2
 
+      - name: Cache kraft-hyperlight
+        id: kraft-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/kraft-hyperlight
+          key: kraft-hyperlight-linux-${{ hashFiles('.github/workflows/test-examples.yml') }}
+
       - name: Build kraft-hyperlight
+        if: steps.kraft-cache.outputs.cache-hit != 'true'
         run: |
           git clone --branch hyperlight-platform --depth 1 \
               https://github.com/danbugs/kraftkit.git /tmp/kraftkit
@@ -223,6 +231,10 @@ jobs:
             expect: "Hello, World! From PowerShell on Hyperlight"
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
 
       - name: Enable KVM permissions (no-op if device absent)
         run: |
@@ -387,15 +399,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Go (for kraft-hyperlight)
-        run: |
-          curl -sL https://go.dev/dl/go1.25.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
-          echo "/usr/local/go/bin" >> $GITHUB_PATH
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+          cache: false
 
       - name: Install just
         uses: extractions/setup-just@v2
 
+      - name: Cache kraft-hyperlight
+        id: kraft-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/kraft-hyperlight
+          key: kraft-hyperlight-linux-${{ hashFiles('.github/workflows/test-examples.yml') }}
+
       - name: Build kraft-hyperlight
+        if: steps.kraft-cache.outputs.cache-hit != 'true'
         run: |
           git clone --branch hyperlight-platform --depth 1 \
               https://github.com/danbugs/kraftkit.git /tmp/kraftkit
@@ -532,17 +552,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install hyperlight-unikraft host binaries
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
+
+      - name: Build host binaries
         shell: pwsh
         run: |
-          cargo install --git https://github.com/${{ github.repository }} `
-            --branch ${{ github.head_ref || github.ref_name }} `
-            hyperlight-unikraft-host `
-            --bin hyperlight-unikraft `
-            --bin multifn-test `
-            --bin pydriver-run `
-            --bin pyhl `
-            --locked --force
+          cd host
+          cargo build --release --bin hyperlight-unikraft --bin multifn-test --bin pydriver-run --bin pyhl
+          Copy-Item target\release\hyperlight-unikraft.exe $env:USERPROFILE\.cargo\bin\ -Force
+          Copy-Item target\release\multifn-test.exe $env:USERPROFILE\.cargo\bin\ -Force
+          Copy-Item target\release\pydriver-run.exe $env:USERPROFILE\.cargo\bin\ -Force
+          Copy-Item target\release\pyhl.exe $env:USERPROFILE\.cargo\bin\ -Force
 
       - name: Download prebuilt image
         uses: actions/download-artifact@v4
@@ -636,6 +658,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: host -> target
+
       # Linux needs /dev/kvm access to run the guest.
       - name: Enable KVM permissions (Linux only)
         if: runner.os == 'Linux'
@@ -660,11 +686,9 @@ jobs:
       - name: Install pyhl
         shell: pwsh
         run: |
-          cargo install --git https://github.com/${{ github.repository }} `
-            --branch ${{ github.head_ref || github.ref_name }} `
-            hyperlight-unikraft-host `
-            --bin pyhl `
-            --locked --force
+          cd host
+          cargo build --release --bin pyhl
+          Copy-Item target/release/pyhl* $env:USERPROFILE/.cargo/bin/ -Force
 
       - name: Download prebuilt python-agent-driver image
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Adds `Swatinem/rust-cache` to every job that runs `cargo build`/`cargo test` (host-checks, bench-linux, bench-windows, runtime-test, runtime-test-windows, pyhl-snapshot-test, publish-kernels)
- Replaces manual `curl` Go tarball download with `actions/setup-go@v5` across all workflows
- Caches the `kraft-hyperlight` binary via `actions/cache` (keyed on workflow file hash) — skips the git clone + Go build on cache hit
- Replaces `cargo install --git` with local `cargo build --release` on Windows jobs (bench-windows, runtime-test-windows, pyhl-snapshot-test) — avoids redundant repo clone and lets rust-cache take effect

Expected savings: ~3-8 min per Cargo job on cache hits, ~60-90s per kraft-hyperlight cache hit, eliminates redundant git clones on Windows.