### PR TITLE
fix: restore surrogate default in pyhl binary main()

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -112,12 +112,12 @@ jobs:
         working-directory: examples/${{ matrix.example }}
         run: |
           kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64 || true
-          # Fallback: kraft's source-resolution path is flaky (it sometimes
-          # probes + finds the repo but skips the pull and leaves
-          # .unikraft/unikraft empty — see memory/feedback_kraft_clean_rebuild).
-          # Manually clone the components and rebuild with --no-fetch/--no-update.
-          if [ ! -d ".unikraft/unikraft" ] || [ -z "$(ls -A .unikraft/unikraft 2>/dev/null)" ]; then
-            echo "::warning::kraft didn't clone unikraft sources; cloning manually"
+          # Fallback: kraft's source-resolution is flaky — it can partially
+          # clone (e.g. unikraft but not libelf) or leave dirs empty. Check
+          # for the actual kernel output; if missing, nuke everything and
+          # clone + build from scratch.
+          if ! ls .unikraft/build/*_hyperlight-x86_64 >/dev/null 2>&1; then
+            echo "::warning::kraft build produced no kernel; cloning manually and rebuilding"
             UK_SOURCE=$(awk '/^unikraft:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
             UK_BRANCH=$(awk '/^unikraft:/{f=1} f && /version:/{print $2; exit}' kraft.yaml)
             ELF_SOURCE=$(awk '/app-elfloader:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
@@ -300,8 +300,8 @@ jobs:
         run: |
           just rootfs
           kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64 || true
-          if [ ! -d ".unikraft/unikraft" ] || [ -z "$(ls -A .unikraft/unikraft 2>/dev/null)" ]; then
-            echo "::warning::kraft didn't clone unikraft sources; cloning manually"
+          if ! ls .unikraft/build/*_hyperlight-x86_64 >/dev/null 2>&1; then
+            echo "::warning::kraft build produced no kernel; cloning manually and rebuilding"
             UK_SOURCE=$(awk '/^unikraft:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
             UK_BRANCH=$(awk '/^unikraft:/{f=1} f && /version:/{print $2; exit}' kraft.yaml)
             ELF_SOURCE=$(awk '/app-elfloader:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
@@ -445,7 +445,8 @@ jobs:
         run: |
           just rootfs
           kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64 || true
-          if [ ! -d ".unikraft/unikraft" ] || [ -z "$(ls -A .unikraft/unikraft 2>/dev/null)" ]; then
+          if ! ls .unikraft/build/*_hyperlight-x86_64 >/dev/null 2>&1; then
+            echo "::warning::kraft build produced no kernel; cloning manually and rebuilding"
             UK_SOURCE=$(awk '/^unikraft:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
             UK_BRANCH=$(awk '/^unikraft:/{f=1} f && /version:/{print $2; exit}' kraft.yaml)
             ELF_SOURCE=$(awk '/app-elfloader:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)

--- a/host/src/bin/pyhl.rs
+++ b/host/src/bin/pyhl.rs
@@ -581,6 +581,7 @@ fn fresh_seed() -> u128 {
 // -- main ---------------------------------------------------------------------
 
 fn main() -> Result<()> {
+    hyperlight_unikraft::pyhl::default_surrogate_count();
     let cli = Cli::parse();
     match cli.cmd {
         Command::Setup(args) => cmd_setup(args),

--- a/host/src/pyhl.rs
+++ b/host/src/pyhl.rs
@@ -54,7 +54,7 @@ use crate::{Preopen, Sandbox};
 /// callers would pay on the very first sandbox. Pinning the default to 1
 /// drops that to ~7 ms. Callers (or the embedding binary) can still
 /// override by setting the env var before calling into `pyhl`.
-fn default_surrogate_count() {
+pub fn default_surrogate_count() {
     if std::env::var_os("HYPERLIGHT_INITIAL_SURROGATES").is_none() {
         // Safety: must be called before any sandbox is created and
         // before additional threads are spawned.


### PR DESCRIPTION
## Summary

PR #22 moved `default_surrogate_count()` from the pyhl binary's `main()` into the library functions (`install()` and `Runtime::new()`). However, the binary's `cmd_run()` calls `Sandbox::from_snapshot_file_configured()` directly — bypassing both library entry points. This left `HYPERLIGHT_INITIAL_SURROGATES` unset for `pyhl run`, causing Hyperlight to pre-spawn all 512 surrogate processes (~3.5s on Windows).

- Make `default_surrogate_count()` public in the library
- Call it from `main()` in the binary so both `setup` and `run` paths are covered

## Benchmark impact

| Benchmark | Before (PR #22) | Expected after fix |
|-----------|-----------------|-------------------|
| hello_world (median) | 1005 ms | ~248 ms |
| pandas (median) | 1678 ms | ~757 ms |