### PR TITLE
ci: simplify release workflow — read version from Cargo.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,6 @@ name: Create release
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version (e.g., 0.2.0) — without the v prefix'
-        required: true
-        type: string
 
 concurrency:
   group: release
@@ -23,44 +18,31 @@ jobs:
         with:
           ref: main
 
-      - name: Validate version input
+      - name: Read version from Cargo.toml
+        id: version
+        working-directory: host
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Validate version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Invalid version '$VERSION' — expected semver like 1.2.3"
+            echo "::error::Invalid version '$VERSION' in Cargo.toml — expected semver like 1.2.3"
             exit 1
           fi
           if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "::error::Tag v$VERSION already exists"
+            echo "::error::Tag v$VERSION already exists — bump the version in Cargo.toml first"
             exit 1
           fi
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: host -> target
-
-      - name: Bump Cargo.toml version
-        working-directory: host
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
-          cargo generate-lockfile
-          grep "^version" Cargo.toml
-
-      - name: Commit version bump
-        run: |
-          VERSION="${{ github.event.inputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add host/Cargo.toml host/Cargo.lock
-          git commit -m "release: v$VERSION"
-          git push origin main
 
       - name: Create tag and GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
           git tag "v$VERSION"
           git push origin "v$VERSION"
           gh release create "v$VERSION" \
@@ -71,5 +53,5 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
           gh workflow run publish-examples.yml --ref "v$VERSION"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,37 @@
+# Releasing hyperlight-unikraft
+
+All examples, kernels, and GHCR images share a single version derived
+from `host/Cargo.toml`.
+
+## Steps
+
+1. **Bump the version** — open a PR that updates `version` in
+   `host/Cargo.toml` (e.g., `"0.1.0"` → `"0.2.0"`). Merge it to main.
+
+2. **Run the release workflow** — go to
+   **Actions → Create release → Run workflow**. No input needed — the
+   workflow reads the version from `Cargo.toml`.
+
+3. **What happens automatically:**
+   - A `v<version>` git tag is created on main.
+   - A GitHub Release is created with auto-generated notes.
+   - The publish workflow is triggered, pushing all GHCR images with
+     both `:latest` and `:v<version>` tags.
+
+## Versioning policy
+
+- New examples or language support → minor bump (0.1.0 → 0.2.0).
+- Bug fixes or documentation → patch bump (0.1.0 → 0.1.1).
+- Breaking API changes → major bump (0.x → 1.0.0, once stable).
+
+All images are republished on every release, even if unchanged. GHCR
+tags are idempotent, so this is harmless.
+
+## crates.io
+
+Publishing to crates.io is blocked until `hyperlight-host` with the
+`disk_snapshot_copy` APIs is available on crates.io (see [#27]).
+Once unblocked, a `cargo publish` step should be added to the release
+workflow.
+
+[#27]: https://github.com/hyperlight-dev/hyperlight-unikraft/issues/27


### PR DESCRIPTION
The release workflow can't push version-bump commits to main due to branch protection rules. Instead, read the version from Cargo.toml directly:

- Remove the version input and Cargo.toml bump step
- Workflow reads version from host/Cargo.toml at HEAD of main
- Fails early if the tag already exists (prompts to bump first)
- Release flow becomes: PR to bump Cargo.toml → merge → Run workflow