### PR TITLE
ci: run all required checks on every PR

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - 'host/**'
-      - '.github/workflows/benchmarks.yml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/host-checks.yml
+++ b/.github/workflows/host-checks.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - 'host/**'
-      - '.github/workflows/host-checks.yml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -4,11 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-    paths:
-      - 'examples/**'
-      - 'runtimes/**'
-      - 'host/**'
-      - '.github/workflows/test-examples.yml'
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Path filters on pull_request triggers cause the required status checks
(host-checks-passed, test-examples-passed, benchmarks-passed) to never
report when a PR only touches CI or docs files, blocking auto-merge.

Remove paths: filters from pull_request triggers so all three workflows
always run on PRs. Keep paths: on push triggers so merges to main only
rebuild when relevant files actually change.