### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2334,7 +2334,7 @@ mod tests {
         fs::write(root.join("etc/passwd"), "fake").unwrap();
         let fs_sb = FsSandbox::new(&root).unwrap();
         let resolved = fs_sb.resolve("/etc/passwd").unwrap();
-        assert_eq!(resolved, root.join("etc/passwd"));
+        assert_eq!(resolved, fs_sb.root().join("etc").join("passwd"));
     }
 
     #[cfg(unix)]
@@ -2447,7 +2447,7 @@ mod tests {
         let root = tmpdir("allow");
         let fs = FsSandbox::new(&root).unwrap();
         let resolved = fs.resolve("subdir/file.txt").unwrap();
-        assert!(resolved.starts_with(&root), "{resolved:?}");
+        assert!(resolved.starts_with(fs.root()), "{resolved:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bumps `hyperlight-unikraft-host` from 0.1.0 to 0.2.0

This release includes all security audit fixes merged via PRs #31–#37:
- **#31** — Symlink escape fix in `FsSandbox::resolve()`
- **#32** — Port-53 DNS bypass fix in `NetworkPolicy`
- **#33** — Resource-limit caps (`MAX_FS_READ`, `MAX_SLEEP_NS`, socket fd overflow)
- **#34** — README and HOST_FUNCTIONS.md documentation refresh
- **#35** — Misc bug fixes (stderr capture safety, SO_TYPE, sockopt hardening)
- **#36** — Remove unused C FFI module
- **#37** — Dead-code cleanup (`FsSandbox::register` removal)

Merging this will trigger the release workflow to publish v0.2.0.

## Test plan

- [ ] CI passes (cargo check, clippy, fmt, all example builds + runtime tests)