### PR TITLE
fix: accept unimplemented socket options, bump 0.3.0

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1176,21 +1176,17 @@ fn register_net_tools(
         let value = args["value"].as_i64().unwrap_or(0) as i32;
         let tbl = t.lock().unwrap();
         let sock = tbl.get_socket(fd)?;
-        // SOL_SOCKET=1, SO_REUSEADDR=2
-        if level == 1 && optname == 2 {
-            sock.set_reuse_address(value != 0)?;
-        // SOL_SOCKET=1, SO_KEEPALIVE=9
-        } else if level == 1 && optname == 9 {
-            sock.set_keepalive(value != 0)?;
-        // IPPROTO_TCP=6, TCP_NODELAY=1
-        } else if level == 6 && optname == 1 {
-            sock.set_nodelay(value != 0)?;
-        } else {
-            return Err(anyhow!(
-                "unsupported socket option: level={}, optname={}",
-                level,
-                optname
-            ));
+        match (level, optname) {
+            // SOL_SOCKET(1), SO_REUSEADDR(2)
+            (1, 2) => sock.set_reuse_address(value != 0)?,
+            // SOL_SOCKET(1), SO_KEEPALIVE(9)
+            (1, 9) => sock.set_keepalive(value != 0)?,
+            // IPPROTO_TCP(6), TCP_NODELAY(1)
+            (6, 1) => sock.set_nodelay(value != 0)?,
+            // Silently accepted — the dispatch round-trip makes
+            // guest-side timeouts and error-reporting opts
+            // counterproductive; the guest's own retry logic suffices.
+            _ => {}
         }
         Ok(json!({}))
     });
@@ -1203,19 +1199,14 @@ fn register_net_tools(
         let optname = args["optname"].as_i64().unwrap_or(0) as i32;
         let tbl = t.lock().unwrap();
         let sock = tbl.get_socket(fd)?;
-        let val: i32 = if level == 1 && optname == 3 {
-            // SOL_SOCKET + SO_TYPE — return the actual socket type
-            tbl.get_sock_type(fd)?
-        } else if level == 1 && optname == 2 {
-            sock.reuse_address()? as i32
-        } else if level == 6 && optname == 1 {
-            sock.nodelay()? as i32
-        } else {
-            return Err(anyhow!(
-                "unsupported socket option: level={}, optname={}",
-                level,
-                optname
-            ));
+        let val: i32 = match (level, optname) {
+            // SOL_SOCKET(1), SO_TYPE(3)
+            (1, 3) => tbl.get_sock_type(fd)?,
+            // SOL_SOCKET(1), SO_REUSEADDR(2)
+            (1, 2) => sock.reuse_address()? as i32,
+            // IPPROTO_TCP(6), TCP_NODELAY(1)
+            (6, 1) => sock.nodelay()? as i32,
+            _ => 0,
         };
         Ok(json!({ "value": val }))
     });


### PR DESCRIPTION
## Summary

- Fix DNS resolution regression introduced in v0.2.0 (PR #37)
- Bump version to 0.3.0

### Root cause

The v0.2.0 `setsockopt`/`getsockopt` hardening changed silent no-ops
into errors for unrecognised socket options. This broke DNS resolution
because musl's resolver sets `IP_RECVERR` (`IPPROTO_IP=0, optname=11`)
on its UDP socket and aborts when the `setsockopt` call fails.

Traced via `HL_DISPATCH_DEBUG=1` — the very first thing after
`net_socket` is `net_setsockopt(level=0, optname=11, value=1)`, which
returned an error and caused the guest to close the socket immediately.

### Fix

Revert `setsockopt` to accepting unknown options silently and
`getsockopt` to returning 0 for unknown options. For a socket-proxy
pattern, the guest OS manages its own socket semantics — unknown
options are harmless configuration hints, not security boundaries.
Known options (`SO_REUSEADDR`, `SO_KEEPALIVE`, `TCP_NODELAY`) are
still applied to the host socket.

## Test plan

- [x] `cargo test --lib` passes on Linux (46/46) and Windows (38/38)
- [x] `cargo clippy --all-targets -- -D warnings` clean on both platforms
- [x] `networking-py urllib_get` passes locally with the fix (was failing with v0.2.0)
- [ ] CI: all checks green including `networking-py` runtime tests