### PR TITLE
chore: remove unused convenience functions and fix timing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ pyhl run my_script.py
 pyhl run my_script.py --repeat 4      # 5 hermetic invocations
 ```
 
-Each `pyhl run` process pays a ~10s cold start (kernel boot + Py_Initialize
-+ preloaded imports) once, then every user invocation (including the
-first) runs hermetic at ~100ms — the driver snapshots the post-warmup
-state and restores between calls, so `__main__` globals and `sys.modules`
-don't leak between runs.
+Each `pyhl run` process pays a one-time warmup (~3 s for `Py_Initialize` +
+preloaded imports) on first call, then snapshots the post-warmup state.
+Every invocation thereafter (including subsequent calls in the same process
+and `--repeat` iterations) restores from the snapshot and runs hermetic
+at ~100 ms — `__main__` globals and `sys.modules` don't leak between runs.
 
 `pyhl setup` is idempotent — re-running reports the existing install and
 exits 0; pass `--force` to overwrite. Artifacts are found via

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -46,7 +46,7 @@
 //! - [`Sandbox::save_snapshot`] writes the current snapshot to disk.
 //! - [`Sandbox::from_snapshot_file`] recreates a sandbox straight from
 //!   the file on disk, bypassing evolve entirely. This is how
-//!   `pyhl run` starts in ~200ms without re-doing `Py_Initialize`.
+//!   `pyhl run` starts in ~100ms without re-doing `Py_Initialize`.
 //!
 //! # Host filesystem
 //!
@@ -2213,63 +2213,8 @@ impl Sandbox {
 }
 
 // ---------------------------------------------------------------------------
-// Convenience: run_vm (single-shot execution)
+// Convenience: run_vm_capture_output (single-shot execution with output)
 // ---------------------------------------------------------------------------
-
-/// Run a Unikraft kernel to completion (single-shot). Thin shim over
-/// [`Sandbox::builder`] for callers that don't need the full fluent API.
-pub fn run_vm(
-    kernel_path: &Path,
-    initrd: Option<&[u8]>,
-    app_args: &[String],
-    config: VmConfig,
-) -> Result<()> {
-    let _ = Sandbox::evolve_inline(kernel_path, initrd, app_args, config, None, &[], None, None)?;
-    Ok(())
-}
-
-/// Run a Unikraft kernel with tool dispatch support.
-pub fn run_vm_with_tools(
-    kernel_path: &Path,
-    initrd: Option<&[u8]>,
-    app_args: &[String],
-    config: VmConfig,
-    tools: ToolRegistry,
-) -> Result<()> {
-    let _ = Sandbox::evolve_inline(
-        kernel_path,
-        initrd,
-        app_args,
-        config,
-        Some(tools),
-        &[],
-        None,
-        None,
-    )?;
-    Ok(())
-}
-
-/// Run a Unikraft kernel with preopened host directories exposed via
-/// `lib/hostfs`. Sandbox escape attempts are rejected host-side.
-pub fn run_vm_with_preopens(
-    kernel_path: &Path,
-    initrd: Option<&[u8]>,
-    app_args: &[String],
-    config: VmConfig,
-    preopens: &[Preopen],
-) -> Result<()> {
-    let _ = Sandbox::evolve_inline(
-        kernel_path,
-        initrd,
-        app_args,
-        config,
-        None,
-        preopens,
-        None,
-        None,
-    )?;
-    Ok(())
-}
 
 /// Output captured from a VM execution.
 pub struct VmOutput {


### PR DESCRIPTION
## Summary
- Removes three unused public convenience functions (`run_vm`, `run_vm_with_tools`, `run_vm_with_preopens`) — the builder API (`Sandbox::builder()`) subsumes all of them and `run_vm_capture_output` (the only used one) is preserved
- Fixes inconsistent timing claims: README now correctly describes the one-time ~3s warmup vs ~100ms per-run latency from snapshot, matching `lib.rs` and `bin/pyhl.rs`

## Test plan
- [x] `cargo test --lib` passes (51 tests)
- [x] `cargo clippy --lib` clean
- [x] `cargo fmt` clean
- [x] Verified `run_vm_capture_output` and `VmOutput` still present