### PR TITLE
fix: cap AllowList learned_ips at 256 entries

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -3223,7 +3223,7 @@ mod tests {
     #[test]
     fn allowlist_learned_ips_capped() {
         use std::net::{IpAddr, Ipv4Addr};
-        let al = AllowList::from_hosts(&["example.com"]).unwrap();
+        let al = AllowList::from_hosts(&["192.0.2.1"]).unwrap();
         // Fill up to the cap
         for i in 0..MAX_LEARNED_IPS {
             let ip = IpAddr::V4(Ipv4Addr::new(10, 0, (i / 256) as u8, (i % 256) as u8));

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -252,7 +252,9 @@ impl AllowList {
 
     fn learn_ip(&self, ip: IpAddr) {
         if let Ok(mut learned) = self.learned_ips.lock() {
-            learned.insert(ip);
+            if learned.len() < MAX_LEARNED_IPS {
+                learned.insert(ip);
+            }
         }
     }
 }
@@ -955,6 +957,9 @@ struct HostSocket {
     socket: Socket,
     sock_type: i32,
 }
+
+/// Maximum number of IPs learned from DNS responses for AllowList policy.
+const MAX_LEARNED_IPS: usize = 256;
 
 const MAX_SOCKETS: usize = 1024;
 
@@ -3213,5 +3218,20 @@ mod tests {
             resp.contains("too large"),
             "expected 'too large' error for net_sendto, got: {resp}"
         );
+    }
+
+    #[test]
+    fn allowlist_learned_ips_capped() {
+        use std::net::{IpAddr, Ipv4Addr};
+        let al = AllowList::from_hosts(&["example.com"]).unwrap();
+        // Fill up to the cap
+        for i in 0..MAX_LEARNED_IPS {
+            let ip = IpAddr::V4(Ipv4Addr::new(10, 0, (i / 256) as u8, (i % 256) as u8));
+            al.learn_ip(ip);
+        }
+        assert_eq!(al.learned_ips.lock().unwrap().len(), MAX_LEARNED_IPS);
+        // One more should NOT be added
+        al.learn_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 0, 1)));
+        assert_eq!(al.learned_ips.lock().unwrap().len(), MAX_LEARNED_IPS);
     }
 }


### PR DESCRIPTION
## Summary
- Caps the `learned_ips` HashSet in `AllowList` at 256 entries to prevent unbounded memory growth from DNS response learning
- A guest performing many DNS lookups for allowed hostnames could previously grow this set without limit
- Adds `allowlist_learned_ips_capped` test verifying the cap

## Test plan
- [x] `cargo test --lib` passes (54 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean