### PR TITLE
fix: enable Python UTF-8 mode to fix open() encoding default

### DIFF
--- a/examples/python-agent-driver/hl_pydriver.c
+++ b/examples/python-agent-driver/hl_pydriver.c
@@ -234,17 +234,12 @@ static void py_run_user_code(const uint8_t *fc, size_t fc_len)
 
 static void py_initialize_once(void)
 {
+	Py_UTF8Mode = 1;
 	Py_Initialize();
 
-	/* sys.argv so scripts that look at it don't crash. Also force
-	 * stdout/stderr to UTF-8 — the guest has no locale configured,
-	 * so Python defaults to ASCII and any non-ASCII char (em-dash,
-	 * smart quotes, …) in a script's print() raises UnicodeEncodeError. */
 	PyRun_SimpleString(
 		"import sys\n"
-		"sys.argv = ['hl_pydriver']\n"
-		"sys.stdout.reconfigure(encoding='utf-8')\n"
-		"sys.stderr.reconfigure(encoding='utf-8')\n");
+		"sys.argv = ['hl_pydriver']\n");
 
 	/* Pre-import the python-agent stack so every subsequent call
 	 * through the v2 callback sees a warm sys.modules and pays only


### PR DESCRIPTION
## Summary
- Sets `Py_UTF8Mode = 1` before `Py_Initialize()` in the Python agent driver
- This makes all file I/O (including `open(path, 'w')`) default to UTF-8 encoding
- Removes the now-redundant `sys.stdout.reconfigure(encoding='utf-8')` / `sys.stderr.reconfigure(encoding='utf-8')` calls since UTF-8 mode handles all streams globally

Previously, only stdout/stderr were reconfigured to UTF-8 via Python-level calls. File operations like `open('/host/file.txt', 'w')` still defaulted to ASCII because the guest has no locale configured. Writing non-ASCII characters (em-dashes, curly quotes, Unicode symbols) would raise `UnicodeEncodeError`.

## Test plan
- [ ] Verify existing pyhl tests still pass (no behavior change for ASCII content)
- [ ] Confirm `open('/host/file.txt', 'w').write('hello -- world')` works without error
- [ ] Confirm `print()` with non-ASCII still works (covered by UTF-8 mode globally)