### PR TITLE
fix: avoid try_clone in net_connect to fix Windows DNS resolution

### DIFF
--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -1237,10 +1237,8 @@ fn handle_net_connect(
     let addr = parse_sockaddr(args)?;
     policy.check(&addr)?;
     let sa: SockAddr = addr.into();
-    let sock = {
-        let tbl = table.lock().unwrap();
-        tbl.get_socket(fd)?.try_clone()?
-    };
+    let tbl = table.lock().unwrap();
+    let sock = tbl.get_socket(fd)?;
     sock.connect_timeout(&sa, SOCKET_TIMEOUT)?;
     Ok(json!({}))
 }


### PR DESCRIPTION
## Summary
- Removes `try_clone()` + drop pattern from `handle_net_connect`, calling `connect_timeout` directly on the socket while holding the table lock
- `connect_timeout` internally toggles non-blocking mode on the socket. When called on a cloned handle (via `try_clone`/`WSADuplicateSocket`), dropping the clone after the call appears to leave the original socket in non-blocking mode on Windows. Subsequent `recvfrom` for DNS queries then returns immediately with `EWOULDBLOCK` instead of blocking for the response, causing "Temporary failure in name resolution"
- Holding the lock during `connect_timeout` is safe because guest dispatch is single-threaded — no other thread contends for the socket table during a call
- This fixes the `runtime-test-windows (networking-py, urllib_get)` test that has been consistently failing since the socket timeout changes landed

## Test plan
- [x] `cargo test --lib` passes (57 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI: `runtime-test-windows (networking-py, urllib_get)` should now pass