### PR TITLE
modifying to update the readme and extend test loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 cargo install just
 
 # 2. kraft-hyperlight (builds Unikraft kernels)
-git clone --branch hyperlight-platform https://github.com/danbugs/kraftkit.git
+git clone --branch plat-hyperlight https://github.com/unikraft/kraftkit/
 cd kraftkit && go build -o kraft-hyperlight ./cmd/kraft
 sudo mv kraft-hyperlight /usr/local/bin/ && cd ..
 

--- a/examples/dotnet-nativeaot/Justfile
+++ b/examples/dotnet-nativeaot/Justfile
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/dotnet-nativeaot-kern
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}}
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}}
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}}
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/dotnet/Justfile
+++ b/examples/dotnet/Justfile
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/dotnet-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}}
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}}
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}}
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/go/Justfile
+++ b/examples/go/Justfile
@@ -1,7 +1,7 @@
 # go on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10    - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/go-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} -- hello
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} -- hello
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} -- hello
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/helloworld-c/Justfile
+++ b/examples/helloworld-c/Justfile
@@ -1,7 +1,7 @@
 # helloworld-c on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10   - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/helloworld-c-kernel:l
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}}
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}}
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}}
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/hostfs-posix-c/Justfile
+++ b/examples/hostfs-posix-c/Justfile
@@ -24,14 +24,14 @@ run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} --mount {{mount_dir}}
 
 [unix]
-run-5:
+run-10:
     mkdir -p {{mount_dir}}
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} --mount {{mount_dir}}
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} --mount {{mount_dir}}
 
 [windows]
-run-5:
+run-10:
     New-Item -ItemType Directory -Force -Path {{mount_dir}} | Out-Null
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} --mount {{mount_dir}}
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} --mount {{mount_dir}}
 
 rootfs:
     docker build --platform linux/amd64 --target cpio -t {{image}}-cpio .

--- a/examples/hostfs-posix-py/Justfile
+++ b/examples/hostfs-posix-py/Justfile
@@ -41,14 +41,14 @@ run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} --mount {{mount_dir}} -- /hostfs_demo.py
 
 [unix]
-run-5:
+run-10:
     mkdir -p {{mount_dir}}
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} --mount {{mount_dir}} -- /hostfs_demo.py
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} --mount {{mount_dir}} -- /hostfs_demo.py
 
 [windows]
-run-5:
+run-10:
     New-Item -ItemType Directory -Force -Path {{mount_dir}} | Out-Null
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} --mount {{mount_dir}} -- /hostfs_demo.py
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} --mount {{mount_dir}} -- /hostfs_demo.py
 
 rootfs:
     docker build --platform linux/amd64 --target cpio -t {{image}}-cpio .

--- a/examples/nodejs/Justfile
+++ b/examples/nodejs/Justfile
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/nodejs-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} -- /app/hello.js
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} -- /app/hello.js
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} -- /app/hello.js
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/powershell/Justfile
+++ b/examples/powershell/Justfile
@@ -1,7 +1,7 @@
 # powershell on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10    - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/powershell-kernel:lat
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} -- -NoProfile -File /scripts/hello.ps1
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} -- -NoProfile -File /scripts/hello.ps1
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} -- -NoProfile -File /scripts/hello.ps1
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/python-tools/Justfile
+++ b/examples/python-tools/Justfile
@@ -1,7 +1,7 @@
 # python-tools on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10    - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-tools-kernel:l
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} --enable-tools -- /test_tools.py
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} --enable-tools -- /test_tools.py
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} --enable-tools -- /test_tools.py
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/python/Justfile
+++ b/examples/python/Justfile
@@ -1,7 +1,7 @@
 # python on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10    - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} -- /hello.py
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} -- /hello.py
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} -- /hello.py
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/rust/Justfile
+++ b/examples/rust/Justfile
@@ -1,7 +1,7 @@
 # rust on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10   - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/rust-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}}
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}}
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}}
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/examples/shell/Justfile
+++ b/examples/shell/Justfile
@@ -1,7 +1,7 @@
 # shell on Hyperlight
 #
 # just run      - Run once
-# just run-5    - Run 5x (snapshot/restore)
+# just run-10    - Run 10x (snapshot/restore)
 # just rootfs   - Build rootfs via Docker (cross-platform)
 # just build    - Build/pull kernel
 # just clean    - Remove build artifacts
@@ -19,9 +19,9 @@ ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/shell-kernel:latest"
 run:
     hyperlight-unikraft {{kernel}} --initrd {{initrd}} --memory {{memory}} -- /demo.sh
 
-# Run 5 times via snapshot/restore
-run-5:
-    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 4 --memory {{memory}} -- /demo.sh
+# Run 10 times via snapshot/restore
+run-10:
+    hyperlight-unikraft {{kernel}} --initrd {{initrd}} --repeat 9 --memory {{memory}} -- /demo.sh
 
 # Build rootfs via Docker (cross-platform)
 rootfs:

--- a/scripts/test-examples.ps1
+++ b/scripts/test-examples.ps1
@@ -1,0 +1,86 @@
+# Run one example per language to verify the build+run pipeline.
+# Languages: C, Rust, Go, .NET, PowerShell, Shell, Python
+#
+# Usage: .\scripts\test-examples.ps1
+
+$ErrorActionPreference = "Continue"
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ExamplesDir = Join-Path $RepoRoot "examples"
+$Failures = 0
+
+function Run-Example {
+    param([string]$Name)
+
+    $dir = Join-Path $ExamplesDir $Name
+    Write-Host "--- $Name ---"
+
+    if (-not (Test-Path $dir)) {
+        Write-Host "  SKIP: directory not found"
+        return
+    }
+
+    Push-Location $dir
+
+    # Build
+    Write-Host -NoNewline "  build: "
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    just build 2>&1 | Out-Null
+    $sw.Stop()
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "ok $($sw.ElapsedMilliseconds)ms"
+    } else {
+        Write-Host "FAILED (exit=$LASTEXITCODE, $($sw.ElapsedMilliseconds)ms)"
+        $script:Failures++
+        Pop-Location
+        return
+    }
+
+    # Rootfs
+    Write-Host -NoNewline "  rootfs: "
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    just rootfs 2>&1 | Out-Null
+    $sw.Stop()
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "ok $($sw.ElapsedMilliseconds)ms"
+    } else {
+        Write-Host "FAILED (exit=$LASTEXITCODE, $($sw.ElapsedMilliseconds)ms)"
+        $script:Failures++
+        Pop-Location
+        return
+    }
+
+    # Run
+    Write-Host -NoNewline "  run: "
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    just run 2>&1 | Out-Null
+    $sw.Stop()
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "ok $($sw.ElapsedMilliseconds)ms"
+    } else {
+        Write-Host "FAILED (exit=$LASTEXITCODE, $($sw.ElapsedMilliseconds)ms)"
+        $script:Failures++
+    }
+
+    Pop-Location
+}
+
+Write-Host "=== test-examples - $(Get-Date) ==="
+Write-Host ""
+
+Run-Example "helloworld-c"
+Run-Example "rust"
+Run-Example "go"
+Run-Example "dotnet"
+Run-Example "powershell"
+Run-Example "shell"
+Run-Example "python"
+
+Write-Host ""
+if ($Failures -gt 0) {
+    Write-Host "DONE with $Failures failure(s)"
+    exit $Failures
+} else {
+    Write-Host "ALL PASSED"
+    exit 0
+}

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Run one example per language to verify the build+run pipeline.
+# Languages: C, Rust, Go, .NET, PowerShell, Shell, Python
+#
+# Usage: ./scripts/test-examples.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXAMPLES_DIR="$REPO_ROOT/examples"
+
+FAILURES=0
+
+now_ms() {
+  local ns
+  ns=$(date +%s%N 2>/dev/null)
+  if [ "${#ns}" -gt 10 ]; then
+    echo $(( ns / 1000000 ))
+  else
+    python3 -c 'import time; print(int(time.time()*1000))'
+  fi
+}
+
+run_example() {
+  local name="$1"
+  local dir="$EXAMPLES_DIR/$name"
+
+  echo "--- $name ---"
+
+  if [ ! -d "$dir" ]; then
+    echo "  SKIP: directory not found"
+    return 1
+  fi
+
+  cd "$dir"
+
+  # Build
+  printf "  build: "
+  local t0 t1 rc
+  t0=$(now_ms)
+  just build < /dev/null > /dev/null 2>&1
+  rc=$?
+  t1=$(now_ms)
+  if [ $rc -eq 0 ]; then
+    echo "ok $((t1 - t0))ms"
+  else
+    echo "FAILED (exit=$rc, $((t1 - t0))ms)"
+    FAILURES=$((FAILURES + 1))
+    cd "$REPO_ROOT"
+    return 1
+  fi
+
+  # Rootfs
+  printf "  rootfs: "
+  t0=$(now_ms)
+  just rootfs < /dev/null > /dev/null 2>&1
+  rc=$?
+  t1=$(now_ms)
+  if [ $rc -eq 0 ]; then
+    echo "ok $((t1 - t0))ms"
+  else
+    echo "FAILED (exit=$rc, $((t1 - t0))ms)"
+    FAILURES=$((FAILURES + 1))
+    cd "$REPO_ROOT"
+    return 1
+  fi
+
+  # Run
+  printf "  run: "
+  t0=$(now_ms)
+  just run < /dev/null > /dev/null 2>&1
+  rc=$?
+  t1=$(now_ms)
+  if [ $rc -eq 0 ]; then
+    echo "ok $((t1 - t0))ms"
+  else
+    echo "FAILED (exit=$rc, $((t1 - t0))ms)"
+    FAILURES=$((FAILURES + 1))
+  fi
+
+  cd "$REPO_ROOT"
+}
+
+echo "=== test-examples — $(date) ==="
+echo ""
+
+run_example "helloworld-c"
+run_example "rust"
+run_example "go"
+run_example "dotnet"
+run_example "powershell"
+run_example "shell"
+run_example "python"
+
+echo ""
+if [ "$FAILURES" -gt 0 ]; then
+  echo "DONE with $FAILURES failure(s)"
+else
+  echo "ALL PASSED"
+fi
+
+exit "$FAILURES"


### PR DESCRIPTION
Update all example repeat loops to 10 iterations for clearer performance comparisons, point README at upstream kraftkit plat-hyperlight branch, and add cross-platform test scripts.

- Update all example Justfiles from `run-5`/`--repeat 4` to `run-10`/`--repeat 9`
- Update README to clone from `unikraft/kraftkit` on the `plat-hyperlight` branch
- Add `scripts/test-examples.sh` (Linux) and `scripts/test-examples.ps1` (Windows) to run one example per language (C, Rust, Go, .NET, PowerShell, Shell, Python) with timing