### PR TITLE
chore: gitignore .claude/ and .pyhl/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ examples/**/obj/
 *.swp
 *.swo
 
+# Tool / runtime caches
+.claude/
+.pyhl/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary
- Add `.claude/` (Claude Code config) and `.pyhl/` (pyhl runtime snapshot cache) to `.gitignore` so they stop showing up in `git status`
- Cleaned up leftover `results-*.txt` test output files from the local tree

## Test plan
- [x] `git status` is clean after the change