### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `host/Cargo.toml` version from 0.4.0 to 0.5.0
- Once merged, trigger the `Create release` workflow to tag and publish

## Changes since v0.4.0
- **Security:** loopback blocking, AllowList learned_ips cap, size caps on fs_read/net_send, DNS pointer-loop guard, socket timeouts, write/truncate caps, mount-root guard
- **Fixes:** Windows socket state corruption, Python UTF-8 mode, benchmark CI for fork PRs, python memory 96→512Mi, ZipInfo timestamp clamping (agent + driver), python-agent CI mount
- **Features:** `rebuild` recipe on all Justfiles, test-examples scripts (Linux + Windows), pyhl integration tests
- **Chore:** gitignore cleanup, examples run-10 update

## Test plan
- [x] Version string is valid semver
- [ ] Merge, then dispatch `Create release` workflow from Actions tab