### PR TITLE
Reduce default --memory to 32Mi, set examples to measured minimums

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -153,6 +153,9 @@ jobs:
   # Full matrix — every example actually runs and its expected output is
   # greped from the guest console. This is the real regression gate;
   # build-example above only catches link-time errors.
+  #
+  # Memory values are read from each example's Justfile at runtime
+  # (the `memory` variable), so the matrix only carries args/expect.
   runtime-test:
     runs-on: ubuntu-latest
     needs: build-example
@@ -165,76 +168,59 @@ jobs:
       matrix:
         include:
           - example: helloworld-c
-            memory: "4Mi"
             args: ""
             expect: "Hello from C on Hyperlight"
           - example: rust
-            memory: "16Mi"
             args: ""
             expect: "Hello from Rust on Hyperlight"
           - example: go
-            memory: "96Mi"
             args: ""
             expect: "Hello from Go on Hyperlight"
           - example: shell
-            memory: "16Mi"
             args: "-- /demo.sh"
             expect: "Hello from Shell on Hyperlight"
           - example: python
-            memory: "512Mi"
             args: "-- /hello.py"
             expect: "Hello from Python on Hyperlight"
           - example: python-tools
-            memory: "1Gi"
             args: "--enable-tools -- /test_tools.py"
             expect: "Tool returned"
           - example: nodejs
-            memory: "512Mi"
             args: "-- /app/hello.js"
             expect: "Hello from Node.js on Hyperlight"
           - example: dotnet
-            memory: "512Mi"
             args: ""
             expect: "Hello, World! From .NET on Hyperlight"
           - example: dotnet-nativeaot
-            memory: "512Mi"
             args: ""
             expect: "Hello, World! From .NET NativeAOT on Hyperlight"
           - example: hostfs-posix-c
-            memory: "16Mi"
             args: ""
             expect: "done\\."
             needs_mount: true
           - example: hostfs-posix-py
-            memory: "512Mi"
             args: "-- /hostfs_demo.py"
             expect: "done\\."
             needs_mount: true
           - example: multifn-c
-            memory: "4Mi"
             args: ""
             expect: "RUN: world"
             driver: multifn-test
           - example: python-agent
-            memory: "1Gi"
             args: "-- /agent.py"
             expect: "done\\."
             needs_mount: true
           - example: python-agent-driver
-            memory: "2Gi"
             args: ""
             expect: "hello from driver"
             driver: pydriver-run
           - example: powershell
-            memory: "1Gi"
             args: "-- -NoProfile -File /scripts/hello.ps1"
             expect: "Hello, World! From PowerShell on Hyperlight"
           - example: networking-py
-            memory: "512Mi"
             args: "--net -- /urllib_get.py"
             expect: "SUCCESS: urllib GET worked!"
           - example: networking-py
-            memory: "512Mi"
             args: "--port 8080 -- /echo_server_test.py"
             expect: "SUCCESS: bind\\+listen on port 8080 allowed"
     steps:
@@ -340,6 +326,11 @@ jobs:
             ls -la .unikraft/build/ *.cpio 2>&1 | head -40 || true
             exit 1
           fi
+          # Read memory from the example's Justfile (single source of truth).
+          memory=$(grep '^memory' Justfile | sed 's/memory.*:= *"//' | sed 's/".*//')
+          if [ -z "$memory" ]; then
+            echo "::notice::No memory variable in Justfile, using binary default"
+          fi
           expect='${{ matrix.expect }}'
           mount_args=""
           if [ "${{ matrix.needs_mount }}" = "true" ]; then
@@ -355,7 +346,11 @@ jobs:
               cmd=(timeout 120 /home/runner/work/hyperlight-unikraft/hyperlight-unikraft/host/target/release/pydriver-run "$kernel" "$cpio" /tmp/tiny.py)
               ;;
             *)
-              cmd=(timeout 120 hyperlight-unikraft -q -m "${{ matrix.memory }}" "$kernel" --initrd "$cpio" $mount_args ${{ matrix.args }})
+              mem_args=""
+              if [ -n "$memory" ]; then
+                mem_args="-m $memory"
+              fi
+              cmd=(timeout 120 hyperlight-unikraft -q $mem_args "$kernel" --initrd "$cpio" $mount_args ${{ matrix.args }})
               ;;
           esac
           set +e
@@ -490,6 +485,8 @@ jobs:
   # The only difference is we can't build the images on Windows (no
   # kraft-hyperlight + no Linux docker), so we download them from the
   # package-images-for-windows job.
+  #
+  # Memory values are read from each example's Justfile at runtime.
   runtime-test-windows:
     runs-on: windows-latest
     needs: package-images-for-windows
@@ -502,76 +499,59 @@ jobs:
       matrix:
         include:
           - example: helloworld-c
-            memory: "4Mi"
             args: ""
             expect: "Hello from C on Hyperlight"
           - example: rust
-            memory: "16Mi"
             args: ""
             expect: "Hello from Rust on Hyperlight"
           - example: go
-            memory: "96Mi"
             args: ""
             expect: "Hello from Go on Hyperlight"
           - example: shell
-            memory: "16Mi"
             args: "-- /demo.sh"
             expect: "Hello from Shell on Hyperlight"
           - example: python
-            memory: "512Mi"
             args: "-- /hello.py"
             expect: "Hello from Python on Hyperlight"
           - example: python-tools
-            memory: "1Gi"
             args: "--enable-tools -- /test_tools.py"
             expect: "Tool returned"
           - example: nodejs
-            memory: "512Mi"
             args: "-- /app/hello.js"
             expect: "Hello from Node.js on Hyperlight"
           - example: dotnet
-            memory: "512Mi"
             args: ""
             expect: "Hello, World! From .NET on Hyperlight"
           - example: dotnet-nativeaot
-            memory: "512Mi"
             args: ""
             expect: "Hello, World! From .NET NativeAOT on Hyperlight"
           - example: hostfs-posix-c
-            memory: "16Mi"
             args: ""
             expect: "done\\."
             needs_mount: true
           - example: hostfs-posix-py
-            memory: "512Mi"
             args: "-- /hostfs_demo.py"
             expect: "done\\."
             needs_mount: true
           - example: multifn-c
-            memory: "4Mi"
             args: ""
             expect: "RUN: world"
             driver: multifn-test
           - example: python-agent
-            memory: "1Gi"
             args: "-- /agent.py"
             expect: "done\\."
             needs_mount: true
           - example: python-agent-driver
-            memory: "2Gi"
             args: ""
             expect: "hello from driver"
             driver: pydriver-run
           - example: powershell
-            memory: "1Gi"
             args: "-- -NoProfile -File /scripts/hello.ps1"
             expect: "Hello, World! From PowerShell on Hyperlight"
           - example: networking-py
-            memory: "512Mi"
             args: "--net -- /urllib_get.py"
             expect: "SUCCESS: urllib GET worked!"
           - example: networking-py
-            memory: "512Mi"
             args: "--port 8080 -- /echo_server_test.py"
             expect: "SUCCESS: bind\\+listen on port 8080 allowed"
     steps:
@@ -614,9 +594,18 @@ jobs:
           $cpio   = (Resolve-Path "image/initrd.cpio").Path
           $expect = '${{ matrix.expect }}'
           $driver = '${{ matrix.driver }}'
-          $memory = '${{ matrix.memory }}'
           $runArgs = '${{ matrix.args }}'
           $needsMount = '${{ matrix.needs_mount }}'
+
+          # Read memory from the example's Justfile (single source of truth).
+          $memory = ''
+          $justfile = "examples/${{ matrix.example }}/Justfile"
+          if (Test-Path $justfile) {
+            $memLine = Get-Content $justfile | Where-Object { $_ -match '^\s*memory\s*:=' }
+            if ($memLine -match '"([^"]+)"') {
+              $memory = $Matches[1]
+            }
+          }
 
           $mountArgs = @()
           if ($needsMount -eq 'true') {
@@ -649,7 +638,11 @@ jobs:
               if ($runArgs -ne '') {
                 $argList = $runArgs.Split(' ') | Where-Object { $_ -ne '' }
               }
-              $out = & hyperlight-unikraft -q -m $memory `
+              $memArgs = @()
+              if ($memory -ne '') {
+                $memArgs = @('-m', $memory)
+              }
+              $out = & hyperlight-unikraft -q @memArgs `
                 $kernel --initrd $cpio @mountArgs @argList 2>&1
               $rc = $LASTEXITCODE
             }

--- a/examples/dotnet-nativeaot/Justfile
+++ b/examples/dotnet-nativeaot/Justfile
@@ -11,7 +11,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/dotnet-nativeaot-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
-memory      := "16Mi"
+memory      := "8Mi"
 image       := "dotnet-nativeaot-hyperlight"
 ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/dotnet-nativeaot-kernel:latest"
 

--- a/examples/helloworld-c/Justfile
+++ b/examples/helloworld-c/Justfile
@@ -11,7 +11,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/helloworld-hyperlight_hyperlight-x86_64"
 initrd      := "hello-initrd.cpio"
-memory      := "4Mi"
+memory      := "2Mi"
 image       := "helloworld-c-hyperlight"
 ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/helloworld-c-kernel:latest"
 

--- a/examples/hostfs-posix-c/Justfile
+++ b/examples/hostfs-posix-c/Justfile
@@ -8,7 +8,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/hostfs-posix-c-hyperlight_hyperlight-x86_64"
 initrd      := "hostfs-posix-c-initrd.cpio"
-memory      := "16Mi"
+memory      := "2Mi"
 image       := "hostfs-posix-c-hyperlight"
 ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/hostfs-posix-c-kernel:latest"
 mount_dir   := "./work"

--- a/examples/hostfs-posix-py/Justfile
+++ b/examples/hostfs-posix-py/Justfile
@@ -8,7 +8,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/hostfs-posix-py-hyperlight_hyperlight-x86_64"
 initrd      := "hostfs-posix-py-initrd.cpio"
-memory      := "96Mi"
+memory      := "512Mi"
 image       := "hostfs-posix-py-hyperlight"
 ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/hostfs-posix-py-kernel:latest"
 mount_dir   := "./work"

--- a/examples/networking-py/Justfile
+++ b/examples/networking-py/Justfile
@@ -11,7 +11,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/networking-py-hyperlight_hyperlight-x86_64"
 initrd      := "initrd.cpio"
-memory      := "512Mi"
+memory      := "32Mi"
 image       := "networking-py-hyperlight"
 
 # Run HTTP GET test (raw sockets)

--- a/examples/python-tools/Justfile
+++ b/examples/python-tools/Justfile
@@ -11,7 +11,7 @@ export DOCKER_BUILDKIT := "0"
 
 kernel      := ".unikraft/build/python-tools-hyperlight_hyperlight-x86_64"
 initrd      := "initrd.cpio"
-memory      := "96Mi"
+memory      := "512Mi"
 image       := "python-tools-hyperlight"
 ghcr_kernel := "ghcr.io/hyperlight-dev/hyperlight-unikraft/python-tools-kernel:latest"
 

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -27,8 +27,8 @@ struct Args {
     #[arg(long)]
     initrd: Option<PathBuf>,
 
-    /// Memory allocation (e.g., 64Mi, 256Mi, 1Gi)
-    #[arg(long, short = 'm', default_value = "64Mi")]
+    /// Memory allocation (e.g., 32Mi, 256Mi, 1Gi)
+    #[arg(long, short = 'm', default_value = "32Mi")]
     memory: String,
 
     /// Stack size (e.g., 8Mi)

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -27,8 +27,8 @@ struct Args {
     #[arg(long)]
     initrd: Option<PathBuf>,
 
-    /// Memory allocation (e.g., 256Mi, 512Mi, 1Gi)
-    #[arg(long, short = 'm', default_value = "512Mi")]
+    /// Memory allocation (e.g., 64Mi, 256Mi, 1Gi)
+    #[arg(long, short = 'm', default_value = "64Mi")]
     memory: String,
 
     /// Stack size (e.g., 8Mi)


### PR DESCRIPTION
## Summary

- Binary-searched the minimum `--memory` each example actually needs to produce correct output
- Updated every example's Justfile to use its measured minimum
- Changed CI to read memory from Justfiles instead of hardcoding values in the workflow matrix
- Lowered the CLI default from `512Mi` to `32Mi` — covers all lightweight examples (C, Rust, Go, .NET, shell) with headroom; heavy runtimes (Python, Node, PowerShell) require explicit `--memory`
- Fixed two under-provisioned examples: `hostfs-posix-py` (was 96Mi, needs 512Mi) and `python-tools` (was 96Mi, needs 512Mi)

### Measured minimums

| Example | Minimum | Previous |
|---|---|---|
| helloworld-c | 2Mi | 4Mi |
| hostfs-posix-c | 2Mi | 16Mi |
| dotnet-nativeaot | 8Mi | 16Mi |
| rust, go, shell, dotnet | 16Mi | 16Mi |
| networking-py | 32Mi | 512Mi |
| hostfs-posix-py, python, python-tools, nodejs | 512Mi | 96Mi-512Mi |
| powershell, python-agent | 1Gi | 1Gi |