### PR TITLE
fix: zipfile.ZipInfo monkey-patch NameError after init cleanup

### DIFF
--- a/examples/python-agent-driver/hl_pydriver.c
+++ b/examples/python-agent-driver/hl_pydriver.c
@@ -265,13 +265,15 @@ static void py_initialize_once(void)
 	 * writer (XLSX is a ZIP container). */
 	PyRun_SimpleString(
 		"import zipfile as _zf\n"
-		"_orig_zi = _zf.ZipInfo.__init__\n"
-		"def _safe_zi(self, filename='NoName', date_time=(1980,1,1,0,0,0)):\n"
-		"    if date_time[0] < 1980:\n"
-		"        date_time = (1980,1,1,0,0,0)\n"
-		"    _orig_zi(self, filename, date_time)\n"
-		"_zf.ZipInfo.__init__ = _safe_zi\n"
-		"del _zf, _orig_zi, _safe_zi\n");
+		"def _patch_zipinfo():\n"
+		"    _orig = _zf.ZipInfo.__init__\n"
+		"    def _safe(self, filename='NoName', date_time=(1980,1,1,0,0,0)):\n"
+		"        if date_time[0] < 1980:\n"
+		"            date_time = (1980,1,1,0,0,0)\n"
+		"        _orig(self, filename, date_time)\n"
+		"    _zf.ZipInfo.__init__ = _safe\n"
+		"_patch_zipinfo()\n"
+		"del _patch_zipinfo, _zf\n");
 
 	/* Monkey-patch time.sleep to call the host via /dev/hcall.
 	 * Unikraft's cooperative scheduler on Hyperlight has no timer

--- a/host/tests/pyhl_runtime.rs
+++ b/host/tests/pyhl_runtime.rs
@@ -118,6 +118,21 @@ fn runtime_pandas_import() {
 }
 
 // ---------------------------------------------------------------------------
+// zipfile.ZipInfo monkey-patch (pre-1980 date clamping)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn runtime_zipinfo_patch_survives_cleanup() {
+    let Some((_home, mut rt)) = setup() else {
+        return;
+    };
+    let timing = rt
+        .run_code("from docx import Document\ndoc = Document()\nprint('ok')")
+        .unwrap();
+    assert_eq!(timing.exit_code, 0);
+}
+
+// ---------------------------------------------------------------------------
 // Exit code propagation
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Fix `NameError: name '_orig_zi' is not defined` when using `python-docx` or any package that creates zip files
- The `zipfile.ZipInfo` monkey-patch in `hl_pydriver.c` used bare globals that were deleted by the cleanup `del` statements, breaking the closure reference; wrapping the patch in a function provides proper closure capture
- Add integration test exercising `from docx import Document` to prevent regression

## Test plan
- [ ] `runtime_zipinfo_patch_survives_cleanup` passes
- [ ] Existing tests unaffected