### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump crate version from 0.6.0 to 0.7.0 in preparation for release

## Changes since v0.6.0
- feat: expand python-agent-driver to 102 pip packages (#80)
- fix: zipfile.ZipInfo monkey-patch NameError after init cleanup (#79)
- fix: increase Hyperlight I/O buffer for large hostfs writes (#81)
- chore: reduce default --memory to 32Mi, set examples to measured minimums (#77)