### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump `hyperlight-unikraft-host` version from 0.7.0 to 0.8.0 in `Cargo.toml` and `Cargo.lock`