### PR TITLE
perf: WHP warm-start optimizations

### DIFF
--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "hyperlight-common"
 version = "0.15.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?branch=disk_snapshot_copy#621cc03beadae3d9158e72d07d3d156abf2b21fd"
+source = "git+https://github.com/danbugs/hyperlight?rev=3ed18580#3ed18580d7f3d0926a6b641159b13b0449b6d930"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.15.0"
-source = "git+https://github.com/hyperlight-dev/hyperlight?branch=disk_snapshot_copy#621cc03beadae3d9158e72d07d3d156abf2b21fd"
+source = "git+https://github.com/danbugs/hyperlight?rev=3ed18580#3ed18580d7f3d0926a6b641159b13b0449b6d930"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1260,7 +1260,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -404,7 +404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -582,7 +582,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 [[package]]
 name = "hyperlight-common"
 version = "0.15.0"
-source = "git+https://github.com/danbugs/hyperlight?rev=3ed18580#3ed18580d7f3d0926a6b641159b13b0449b6d930"
+source = "git+https://github.com/danbugs/hyperlight?rev=5cf37d92#5cf37d92262c918e7d633577a6cf946fb1f069bd"
 dependencies = [
  "anyhow",
  "flatbuffers",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "hyperlight-host"
 version = "0.15.0"
-source = "git+https://github.com/danbugs/hyperlight?rev=3ed18580#3ed18580d7f3d0926a6b641159b13b0449b6d930"
+source = "git+https://github.com/danbugs/hyperlight?rev=5cf37d92#5cf37d92262c918e7d633577a6cf946fb1f069bd"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -1260,7 +1260,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1844,7 +1844,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/bin/pyhl.rs"
 
 [dependencies]
 # danbugs/hyperlight perf/whp-warm-start — snapshot file support + WHP warm-start optimizations.
-hyperlight-host = { git = "https://github.com/danbugs/hyperlight", rev = "3ed18580", features = ["executable_heap", "hw-interrupts", "whp-no-surrogate"] }
+hyperlight-host = { git = "https://github.com/danbugs/hyperlight", rev = "5cf37d92", features = ["executable_heap", "hw-interrupts", "whp-no-surrogate"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 memmap2 = "0.9"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -27,9 +27,8 @@ name = "pyhl"
 path = "src/bin/pyhl.rs"
 
 [dependencies]
-# hyperlight-dev/hyperlight#1373 — Ludvig's Snapshot::to_file/from_file
-# Uses PAGE_READONLY mapping (no host commit charge per VM).
-hyperlight-host = { git = "https://github.com/hyperlight-dev/hyperlight", branch = "disk_snapshot_copy", features = ["executable_heap", "hw-interrupts"] }
+# danbugs/hyperlight perf/whp-warm-start — snapshot file support + WHP warm-start optimizations.
+hyperlight-host = { git = "https://github.com/danbugs/hyperlight", rev = "3ed18580", features = ["executable_heap", "hw-interrupts", "whp-no-surrogate"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 memmap2 = "0.9"

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2008,10 +2008,9 @@ pub struct Sandbox {
     inner: MultiUseSandbox,
     /// Post-init snapshot for fast restore between calls.
     snapshot: Option<Arc<Snapshot>>,
-    /// File mapping to re-register after snapshot restore.
-    /// Snapshot restore unmaps all non-snapshot regions.
+    /// When set, restore uses the preserving variant to keep the
+    /// read-only file mapping alive across restores.
     file_mapping_path: Option<std::path::PathBuf>,
-    file_mapping_base: u64,
     exit_code: Arc<AtomicI32>,
     /// Shared socket table — cleared on [`Sandbox::restore`] so that
     /// host-side fds don't leak across guest restore cycles.
@@ -2247,7 +2246,7 @@ impl Sandbox {
             tools_ref.dispatch(&payload)
         })?;
 
-        Self::finish_evolve(usbox, None, 0, exit_code, sleep_cancel, socket_table)
+        Self::finish_evolve(usbox, None, exit_code, sleep_cancel, socket_table)
     }
 
     /// Low-level: boot with a zero-copy mapped initrd file. Prefer the builder.
@@ -2304,7 +2303,6 @@ impl Sandbox {
         Self::finish_evolve(
             usbox,
             initrd_path.map(|p| p.to_path_buf()),
-            INITRD_MAP_BASE,
             exit_code,
             sleep_cancel,
             socket_table,
@@ -2314,7 +2312,6 @@ impl Sandbox {
     fn finish_evolve(
         usbox: UninitializedSandbox,
         file_mapping_path: Option<std::path::PathBuf>,
-        file_mapping_base: u64,
         exit_code: Arc<AtomicI32>,
         sleep_cancel: SleepCancel,
         socket_table: Option<Arc<Mutex<SocketTable>>>,
@@ -2325,7 +2322,6 @@ impl Sandbox {
             inner,
             snapshot,
             file_mapping_path,
-            file_mapping_base,
             exit_code,
             socket_table,
             sleep_cancel,
@@ -2338,15 +2334,12 @@ impl Sandbox {
     /// guest memory to the state captured after init.
     pub fn restore(&mut self) -> Result<()> {
         if let Some(ref snap) = self.snapshot {
-            self.inner.restore(snap.clone())?;
+            if self.file_mapping_path.is_some() {
+                self.inner.restore_preserving_file_mappings(snap.clone())?;
+            } else {
+                self.inner.restore(snap.clone())?;
+            }
         }
-        // Re-register file mapping after restore (snapshot restore
-        // unmaps all non-snapshot regions including file mappings)
-        if let Some(ref path) = self.file_mapping_path {
-            self.inner
-                .map_file_cow(path, self.file_mapping_base, Some("initrd"))?;
-        }
-        // Close leaked host-side sockets the guest "forgot" about.
         if let Some(ref table) = self.socket_table {
             table.lock().unwrap().clear();
         }
@@ -2543,7 +2536,6 @@ impl Sandbox {
             inner,
             snapshot: Some(arc),
             file_mapping_path: initrd,
-            file_mapping_base: INITRD_MAP_BASE,
             exit_code,
             socket_table,
             sleep_cancel,


### PR DESCRIPTION
## Summary

Optimizes WHP snapshot-restore latency on Windows (~8x cold load, ~6x steady-state restore).

**Hyperlight changes** ([danbugs/hyperlight@perf/whp-warm-start](https://github.com/danbugs/hyperlight/tree/perf/whp-warm-start)):

- **Batched vCPU register resets** — single `WHvSetVirtualProcessorRegisters` call for GPR + debug + special registers instead of three separate calls
- **Cached xsave template** — built once at VM creation, applied as a single write per restore instead of read-modify-write
- **`restore_preserving_file_mappings`** — skips unmapping/remapping read-only file regions (e.g., initrd) during restore; safe because they are `PAGE_READONLY` at the hypervisor level and guest writes go through CoW via scratch
- **`whp-no-surrogate` feature** — for single-partition-per-process scenarios: `VirtualAlloc` instead of `CreateFileMappingA`, `WHvMapGpaRange` instead of `WHvMapGpaRange2`; scratch zeroing uses `fill(0)` in-place (MEM_DECOMMIT+MEM_COMMIT was removed as it desyncs the WHP GPA mapping)

**This repo:**

- Calls `restore_preserving_file_mappings` when an initrd mapping exists
- Enables `whp-no-surrogate`

## Test plan

- [x] Correct output over 100+ repeat invocations on Windows
- [x] Hermetic isolation verified (identical output per run)
- [ ] CI benchmarks