### PR TITLE
feat: add urunc-ready OCI image for helloworld-c

### DIFF
--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -165,6 +165,71 @@ jobs:
             docker push $VERSION_TAG
           fi
 
+  # Publish a urunc-ready OCI image for helloworld-c (kernel + initrd + annotations)
+  publish-urunc-hello:
+    needs: [publish-kernels]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.1'
+          cache: false
+
+      - name: Cache kraft-hyperlight
+        id: kraft-cache
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/bin/kraft-hyperlight
+          key: kraft-hyperlight-linux-${{ hashFiles('.github/workflows/publish-examples.yml') }}
+
+      - name: Install kraft-hyperlight
+        if: steps.kraft-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --branch hyperlight-platform --depth 1 https://github.com/danbugs/kraftkit.git /tmp/kraftkit
+          cd /tmp/kraftkit && go build -o /usr/local/bin/kraft-hyperlight ./cmd/kraft
+
+      - name: Build kernel
+        working-directory: examples/helloworld-c
+        run: |
+          kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64 || true
+          if [ ! -f ".unikraft/build/helloworld-hyperlight_hyperlight-x86_64" ]; then
+            UK_SOURCE=$(awk '/^unikraft:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
+            UK_BRANCH=$(awk '/^unikraft:/{f=1} f && /version:/{print $2; exit}' kraft.yaml)
+            ELF_SOURCE=$(awk '/app-elfloader:/{f=1} f && /source:/{print $2; exit}' kraft.yaml)
+            ELF_BRANCH=$(awk '/app-elfloader:/{f=1} f && /version:/{print $2; exit}' kraft.yaml)
+            mkdir -p .unikraft/apps .unikraft/libs
+            rm -rf .unikraft/unikraft .unikraft/apps/elfloader
+            git clone --branch "$UK_BRANCH" --depth 1 "$UK_SOURCE" .unikraft/unikraft
+            git clone --branch "$ELF_BRANCH" --depth 1 "$ELF_SOURCE" .unikraft/apps/elfloader
+            git clone --branch staging --depth 1 https://github.com/unikraft/lib-libelf.git .unikraft/libs/libelf
+            rm -rf .unikraft/build
+            kraft-hyperlight --no-prompt build --plat hyperlight --arch x86_64
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push urunc image
+        working-directory: examples/helloworld-c
+        run: |
+          IMAGE=${{ env.IMAGE_BASE }}/hello-hyperlight-unikraft:latest
+          docker build --platform linux/amd64 -f urunc.Dockerfile -t $IMAGE .
+          docker push $IMAGE
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            VERSION_TAG=${{ env.IMAGE_BASE }}/hello-hyperlight-unikraft:${{ github.ref_name }}
+            docker tag $IMAGE $VERSION_TAG
+            docker push $VERSION_TAG
+          fi
+
   # Publish the python-agent-driver rootfs CPIO as its own image so
   # `pyhl setup` can pull the initrd (and kernel, above) from GHCR
   # without having to build the driver image locally.

--- a/examples/helloworld-c/Justfile
+++ b/examples/helloworld-c/Justfile
@@ -46,6 +46,10 @@ build:
     docker cp {{image}}-kernel-tmp:/kernel ./{{kernel}}
     docker rm -f {{image}}-kernel-tmp
 
+# Build urunc-compatible OCI image (requires kernel to be built first)
+urunc-image: build
+    docker build --platform linux/amd64 -f urunc.Dockerfile -t hello-hyperlight-unikraft:latest .
+
 # Clean + rebuild everything
 rebuild: clean build rootfs
 

--- a/examples/helloworld-c/URUNC.md
+++ b/examples/helloworld-c/URUNC.md
@@ -1,0 +1,48 @@
+# Running helloworld-c with urunc
+
+This example can be packaged as an OCI image for [urunc](https://github.com/urunc-dev/urunc), the CNCF unikernel container runtime. urunc treats `hyperlight-unikraft` as a host-level VMM (like QEMU), with the OCI image carrying the Unikraft kernel and initrd payload.
+
+## Prerequisites
+
+- `hyperlight-unikraft` installed on the host (the VMM)
+- `urunc` and `containerd-shim-urunc-v2` installed on the host
+- `/dev/kvm` available
+- `containerd` running
+
+## Build
+
+```bash
+just urunc-image
+```
+
+This builds the kernel via `kraft-hyperlight`, compiles `hello.c` into a static-PIE binary packed as a CPIO initrd, and produces a `hello-hyperlight-unikraft:latest` Docker image.
+
+A pre-built image is also available at `ghcr.io/hyperlight-dev/hyperlight-unikraft/hello-hyperlight-unikraft:latest`.
+
+## Run
+
+```bash
+# Import into containerd
+docker save hello-hyperlight-unikraft:latest -o /tmp/hello.tar
+sudo ctr images import /tmp/hello.tar
+
+# Run via urunc
+sudo ctr run --rm --runtime io.containerd.urunc.v2 \
+  docker.io/library/hello-hyperlight-unikraft:latest hello-test
+```
+
+## How it works
+
+The OCI image contains just three files:
+
+- `/unikernel/kernel` — Unikraft kernel ELF (built for the Hyperlight platform)
+- `/unikernel/initrd.cpio` — CPIO archive containing `/bin/hello` (static-PIE C binary)
+- `/urunc.json` — urunc annotations identifying this as a `hyperlight` + `unikraft` workload
+
+When urunc runs the image, it finds `hyperlight-unikraft` on the host, bind-mounts it along with `/dev/kvm` into an isolated rootfs, and exec's:
+
+```
+hyperlight-unikraft /unikernel/kernel --initrd /unikernel/initrd.cpio --memory <bytes>
+```
+
+This boots a Hyperlight micro-VM running Unikraft, which mounts the initrd and executes the hello binary.

--- a/examples/helloworld-c/urunc.Dockerfile
+++ b/examples/helloworld-c/urunc.Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.20 AS build
+RUN apk add --no-cache musl-dev gcc cpio findutils
+COPY hello.c /src/hello.c
+RUN gcc -static-pie -fPIE -fno-stack-protector -o /src/hello /src/hello.c
+RUN mkdir -p /rootfs/bin && cp /src/hello /rootfs/bin/hello \
+    && cd /rootfs && find . | cpio -o -H newc > /output.cpio 2>/dev/null
+
+FROM scratch
+COPY .unikraft/build/helloworld-hyperlight_hyperlight-x86_64 /unikernel/kernel
+COPY --from=build /output.cpio /unikernel/initrd.cpio
+COPY urunc.json /urunc.json
+LABEL "com.urunc.unikernel.unikernelType"="unikraft"
+LABEL "com.urunc.unikernel.hypervisor"="hyperlight"
+LABEL "com.urunc.unikernel.binary"="/unikernel/kernel"
+LABEL "com.urunc.unikernel.initrd"="/unikernel/initrd.cpio"

--- a/examples/helloworld-c/urunc.json
+++ b/examples/helloworld-c/urunc.json
@@ -1,0 +1,6 @@
+{
+  "com.urunc.unikernel.unikernelType": "dW5pa3JhZnQ=",
+  "com.urunc.unikernel.hypervisor": "aHlwZXJsaWdodA==",
+  "com.urunc.unikernel.binary": "L3VuaWtlcm5lbC9rZXJuZWw=",
+  "com.urunc.unikernel.initrd": "L3VuaWtlcm5lbC9pbml0cmQuY3Bpbw=="
+}

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64",


### PR DESCRIPTION
Add a urunc-compatible OCI image for the helloworld-c example, enabling hyperlight-unikraft workloads to run on Kubernetes via [urunc](https://github.com/urunc-dev/urunc) (CNCF unikernel container runtime).

urunc treats `hyperlight-unikraft` as a host-level VMM (like QEMU), with the OCI image carrying the Unikraft kernel + initrd payload. This follows the same pattern as `hello-qemu-unikraft` and `hello-firecracker-unikraft` in the urunc ecosystem.

- Add `urunc.Dockerfile`, `urunc.json`, and `URUNC.md` to `examples/helloworld-c/`
- Add `just urunc-image` recipe for local builds
- Add `publish-urunc-hello` CI job to publish to GHCR
- Sync `Cargo.lock` with 0.9.0 version bump

Related: [urunc-dev/urunc#140](https://github.com/urunc-dev/urunc/issues/140), [urunc-dev/urunc#632](https://github.com/urunc-dev/urunc/pull/632)