### PR TITLE
fix: address copilot feedback on urunc image

### DIFF
--- a/examples/helloworld-c/.dockerignore
+++ b/examples/helloworld-c/.dockerignore
@@ -1,0 +1,17 @@
+.unikraft/unikraft
+.unikraft/apps
+.unikraft/libs
+.unikraft/build/config
+.unikraft/build/kconfig
+.unikraft/build/lib*
+.unikraft/build/Makefile
+.unikraft/build/*.cmd
+.unikraft/build/*.py
+.unikraft/build/*.o
+.unikraft/build/*.dbg*
+.unikraft/build/*.bootinfo*
+.unikraft/build/include
+.unikraft/build/appelfloader*
+.unikraft/build/provided_syscalls*
+.unikraft/build/libraries*
+hello

--- a/examples/helloworld-c/URUNC.md
+++ b/examples/helloworld-c/URUNC.md
@@ -39,7 +39,7 @@ The OCI image contains just three files:
 - `/unikernel/initrd.cpio` — CPIO archive containing `/bin/hello` (static-PIE C binary)
 - `/urunc.json` — urunc annotations identifying this as a `hyperlight` + `unikraft` workload
 
-When urunc runs the image, it finds `hyperlight-unikraft` on the host, bind-mounts it along with `/dev/kvm` into an isolated rootfs, and exec's:
+When urunc runs the image, it finds `hyperlight-unikraft` on the host, bind-mounts it along with `/dev/kvm` into an isolated rootfs, and execs:
 
 ```
 hyperlight-unikraft /unikernel/kernel --initrd /unikernel/initrd.cpio --memory <bytes>


### PR DESCRIPTION
## Summary

Follow-up to #89. Addresses two valid Copilot review comments:

- Add `.dockerignore` to `examples/helloworld-c/` to exclude `.unikraft/` source/build artifacts from the Docker build context (was sending ~280MB unnecessarily)
- Fix "exec's" → "execs" grammar in `URUNC.md`

Skipped the `sudo mv` suggestion for kraft-hyperlight install — the existing `publish-kernels` job in the same workflow uses the same direct-write pattern and works fine.