### PR TITLE
fix: move INITRD_MAP_BASE past LAPIC MMIO region

### DIFF
--- a/examples/dotnet-nativeaot/HelloNativeAot.csproj
+++ b/examples/dotnet-nativeaot/HelloNativeAot.csproj
@@ -7,6 +7,6 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" Version="9.0.16" />
+    <PackageReference Include="runtime.linux-musl-x64.Microsoft.DotNet.ILCompiler" Version="9.0.17" />
   </ItemGroup>
 </Project>

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2282,9 +2282,11 @@ impl Sandbox {
         let mut usbox = UninitializedSandbox::new(env, Some(config.sandbox_config()))?;
 
         // Map the initrd file (zero-copy via mmap)
-        // Place at 3 GiB — high enough to not overlap any reasonable
-        // primary shared memory region, within the 4 GiB identity map.
-        const INITRD_MAP_BASE: u64 = 0xC000_0000; // 3 GiB
+        // Place past the x86 LAPIC MMIO page (0xFEE0_0000) so that
+        // large initrds (>1 GiB) don't overlap it and trigger EEXIST
+        // from KVM_SET_USER_MEMORY_REGION on kernels where in-kernel
+        // IRQCHIP reserves that range.
+        const INITRD_MAP_BASE: u64 = 0xFEF0_0000;
         if let Some(path) = initrd_path {
             usbox.map_file_cow(path, INITRD_MAP_BASE, Some("initrd"))?;
         }
@@ -2527,7 +2529,7 @@ impl Sandbox {
 
         let mut inner = MultiUseSandbox::from_snapshot(arc.clone(), host_funcs, None)?;
 
-        const INITRD_MAP_BASE: u64 = 0xC000_0000;
+        const INITRD_MAP_BASE: u64 = 0xFEF0_0000;
         if let Some(ref initrd_path) = initrd {
             inner.map_file_cow(initrd_path, INITRD_MAP_BASE, Some("initrd"))?;
         }

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2469,7 +2469,7 @@ impl Sandbox {
     }
 
     /// Load a snapshot with an initrd file re-mapped at the standard
-    /// guest VA (0xC000_0000). Required when the snapshot was taken
+    /// guest VA (0xFEF0_0000). Required when the snapshot was taken
     /// from a cpiovfs-backed guest whose VFS nodes point into the
     /// initrd region.
     pub fn from_snapshot_file_with_initrd<P: AsRef<Path>, I: AsRef<Path>>(


### PR DESCRIPTION
## Summary

- Moves both `INITRD_MAP_BASE` constants from `0xC000_0000` (3 GiB) to `0xFEF0_0000` (just past the LAPIC MMIO page at `0xFEE0_0000`)

When the initrd exceeds ~1 GiB (as it does in v0.9.0's python-agent-driver), the mapping at `0xC000_0000` spans the LAPIC MMIO region at `0xFEE0_0000`. On kernels where `KVM_CREATE_IRQCHIP` reserves that range, `KVM_SET_USER_MEMORY_REGION` rejects the mapping with `EEXIST`.

The corresponding guest-side constant in Unikraft is updated in unikraft/unikraft#1850.

Fixes: microsoft/mxc#525

## Test plan

- Built the Unikraft kernel with the matching guest-side change via `kraft-hyperlight build`
- Ran `pydriver-run` with the patched kernel + host against a ~1.07 GiB initrd
- Confirmed via `strace` that the initrd slot maps at `guest_phys_addr=0xfef00000` (past the LAPIC)
- Guest boots and runs Python successfully