### PR TITLE
feat: use hyperlight-host 0.16.0 from crates.io

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -483,10 +483,29 @@ jobs:
       - name: "Snapshot size"
         shell: pwsh
         run: |
+          Add-Type -TypeDefinition @"
+          using System;
+          using System.Runtime.InteropServices;
+          public class SparseFileHelper {
+              [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+              public static extern uint GetCompressedFileSizeW(string lpFileName, out uint lpFileSizeHigh);
+          }
+          "@
+          function Get-CompressedSize($path) {
+              $high = [uint32]0
+              $low = [SparseFileHelper]::GetCompressedFileSizeW($path, [ref]$high)
+              if ($low -eq 0xFFFFFFFF) {
+                  $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                  if ($err -ne 0) { return (Get-Item $path).Length }
+              }
+              return ([uint64]$high -shl 32) -bor [uint64]$low
+          }
           $snap = ".pyhl\snapshot"
           $files = Get-ChildItem -Path $snap -Recurse -File
           $apparentMiB = [math]::Round(($files | Measure-Object -Property Length -Sum).Sum / 1MB)
-          $diskMiB = $apparentMiB
+          $diskBytes = [uint64]0
+          foreach ($f in $files) { $diskBytes += Get-CompressedSize $f.FullName }
+          $diskMiB = [math]::Round($diskBytes / 1MB)
           Write-Host "| Metric | Value |"
           Write-Host "|--------|-------|"
           Write-Host "| Apparent size | ${apparentMiB} MiB |"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -287,9 +287,9 @@ jobs:
       - name: "Snapshot size"
         if: steps.kvm_check.outputs.available == 'true'
         run: |
-          snap=".pyhl/snapshot.hls"
-          apparent=$(($(stat -c '%s' "$snap") / 1024 / 1024))
-          disk=$(($(stat -c '%b' "$snap") * 512 / 1024 / 1024))
+          snap=".pyhl/snapshot"
+          apparent=$(($(find "$snap" -type f -exec stat -c '%s' {} + | paste -sd+ | bc) / 1024 / 1024))
+          disk=$(($(find "$snap" -type f -exec stat -c '%b' {} + | paste -sd+ | bc) * 512 / 1024 / 1024))
           echo "| Metric | Value |"
           echo "|--------|-------|"
           echo "| Apparent size | ${apparent} MiB |"
@@ -483,27 +483,10 @@ jobs:
       - name: "Snapshot size"
         shell: pwsh
         run: |
-          $snap = ".pyhl\snapshot.hls"
-          $f = Get-Item $snap
-          $apparentMiB = [math]::Round($f.Length / 1MB)
-          # GetCompressedFileSize returns actual on-disk allocation for sparse files
-          $wide = $f.FullName
-          Add-Type -TypeDefinition @"
-          using System;
-          using System.Runtime.InteropServices;
-          public class SparseHelper {
-            [DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
-            public static extern uint GetCompressedFileSizeW(string lpFileName, out uint lpFileSizeHigh);
-          }
-          "@ -ErrorAction SilentlyContinue
-          $high = [uint32]0
-          $low = [SparseHelper]::GetCompressedFileSizeW($wide, [ref]$high)
-          if ($low -ne [uint32]::MaxValue) {
-            $diskBytes = ([uint64]$high -shl 32) -bor [uint64]$low
-            $diskMiB = [math]::Round($diskBytes / 1MB)
-          } else {
-            $diskMiB = $apparentMiB
-          }
+          $snap = ".pyhl\snapshot"
+          $files = Get-ChildItem -Path $snap -Recurse -File
+          $apparentMiB = [math]::Round(($files | Measure-Object -Property Length -Sum).Sum / 1MB)
+          $diskMiB = $apparentMiB
           Write-Host "| Metric | Value |"
           Write-Host "|--------|-------|"
           Write-Host "| Apparent size | ${apparentMiB} MiB |"

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -177,6 +177,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -414,6 +423,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,13 +652,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -740,6 +862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flatbuffers"
 version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +886,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -892,6 +1026,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,13 +1128,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyperlight-common"
-version = "0.15.0"
-source = "git+https://github.com/danbugs/hyperlight?rev=5cf37d92#5cf37d92262c918e7d633577a6cf946fb1f069bd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436dac5cc08da3db27de38b174a9b22498ab6443aaffd83b97f66a5d2f1d74cc"
 dependencies = [
  "anyhow",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "bytes",
+ "fixedbitset",
  "flatbuffers",
  "log",
+ "smallvec",
  "spin",
  "thiserror 2.0.18",
  "tracing",
@@ -992,8 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-host"
-version = "0.15.0"
-source = "git+https://github.com/danbugs/hyperlight?rev=5cf37d92#5cf37d92262c918e7d633577a6cf946fb1f069bd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef3edc7875e70a3b5cc291a17f78cfc352e24c9a665a5a1bbdbc46ada3df43b5"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1005,6 +1172,7 @@ dependencies = [
  "crossbeam-channel",
  "flatbuffers",
  "goblin",
+ "hex",
  "hyperlight-common",
  "kvm-bindings",
  "kvm-ioctls",
@@ -1014,15 +1182,18 @@ dependencies = [
  "metrics",
  "mshv-bindings",
  "mshv-ioctls",
+ "oci-spec",
  "page_size",
  "rand 0.10.1",
  "rust-embed",
+ "serde",
  "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
  "termcolor",
  "thiserror 2.0.18",
  "tracing",
  "tracing-core",
- "tracing-log",
  "uuid",
  "vmm-sys-util",
  "windows",
@@ -1041,7 +1212,6 @@ dependencies = [
  "flate2",
  "hyperlight-host",
  "libc",
- "memmap2",
  "nix",
  "serde_json",
  "socket2 0.5.10",
@@ -1166,6 +1336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kvm-bindings"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,9 +1464,9 @@ dependencies = [
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
 dependencies = [
  "bitflags 2.13.0",
  "kvm-bindings",
@@ -1410,15 +1601,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap2"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1707,23 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "memchr",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6f876ad774d6a676f7e968f5c3edacc32f90e65fe680a8b686235396556fb"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1750,6 +1949,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "globset",
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2004,7 +2215,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2065,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
 dependencies = [
  "lock_api",
 ]
@@ -2083,6 +2305,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -2262,17 +2502,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
 ]
 
 [[package]]

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -48,7 +48,7 @@ nix = { version = "0.29", features = ["fs"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
+windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock", "Win32_System_IO", "Win32_System_Ioctl"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -31,11 +31,9 @@ default = []
 wasm-host-fns = ["dep:wasmtime", "dep:wasmtime-wasi"]
 
 [dependencies]
-# danbugs/hyperlight perf/whp-warm-start — snapshot file support + WHP warm-start optimizations.
-hyperlight-host = { git = "https://github.com/danbugs/hyperlight", rev = "5cf37d92", features = ["executable_heap", "hw-interrupts", "whp-no-surrogate"] }
+hyperlight-host = { version = "0.16.0", features = ["executable_heap", "hw-interrupts"] }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
-memmap2 = "0.9"
 serde_json = "1"
 base64 = "0.22"
 socket2 = { version = "0.5", features = ["all"] }
@@ -50,7 +48,7 @@ nix = { version = "0.29", features = ["fs"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_IO", "Win32_System_Ioctl", "Win32_Storage_FileSystem", "Win32_Networking_WinSock"] }
+windows-sys = { version = "0.61", features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/host/examples/pyhl_as_library.rs
+++ b/host/examples/pyhl_as_library.rs
@@ -3,7 +3,7 @@
 //!
 //! Usage: `cargo run --release --example pyhl_as_library -- <code>`
 //!
-//! Assumes `pyhl setup` has already run and `.pyhl/snapshot.hls` exists
+//! Assumes `pyhl setup` has already run and `.pyhl/snapshot/` exists
 //! in the current directory (or override with `PYHL_HOME`).
 
 use hyperlight_unikraft::{pyhl, Preopen};
@@ -22,7 +22,7 @@ fn main() -> anyhow::Result<()> {
     // expose host directories via the guest's hostfs.
     let mounts: &[Preopen] = &[];
 
-    let mut rt = pyhl::Runtime::new(&home, mounts, None, None)?;
+    let mut rt = pyhl::Runtime::new(&home, mounts, None, None, None)?;
 
     eprintln!("-- first run (hermetic from loaded snapshot) --");
     let t1 = rt.run_code(&code)?;

--- a/host/examples/test_cpiovfs.rs
+++ b/host/examples/test_cpiovfs.rs
@@ -21,9 +21,12 @@ fn main() -> anyhow::Result<()> {
         sbox.snapshot_now()?;
         eprintln!("  snapshot OK");
 
-        let snap_path = "/tmp/cpiovfs_snapshot.hls";
+        let snap_path = "/tmp/cpiovfs_snapshot";
         sbox.save_snapshot(snap_path)?;
-        let snap_size = std::fs::metadata(snap_path)?.len();
+        let snap_size: u64 = std::fs::read_dir(snap_path)?
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.metadata().ok().map(|m| m.len()))
+            .sum();
         eprintln!(
             "  snapshot size: {} MiB ({} bytes)",
             snap_size / 1024 / 1024,

--- a/host/src/bin/pydriver_run.rs
+++ b/host/src/bin/pydriver_run.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     let t_evolve = Instant::now();
     let mut sandbox = Sandbox::builder(&kernel)
         .initrd_file(&initrd)
-        .heap_size(5 * 512 * 1024 * 1024)
+        .heap_size(1280 * 1024 * 1024)
         .build()?;
     eprintln!(
         "[timing] evolve={:.1}ms",

--- a/host/src/bin/pyhl.rs
+++ b/host/src/bin/pyhl.rs
@@ -546,7 +546,7 @@ fn cmd_run(args: RunArgs) -> Result<()> {
     // Py_Initialize + preloaded modules, captured the state, and
     // persisted it to snapshot/. Here we load that OCI layout back and
     // instantiate a sandbox directly — no kernel boot, no Python init.
-    if !snapshot.is_dir() {
+    if !snapshot.join("index.json").is_file() {
         return Err(anyhow!(
             "no warmed-up snapshot at {}.\n\
              run `pyhl setup` first (or `pyhl setup --force` if you have\n\

--- a/host/src/bin/pyhl.rs
+++ b/host/src/bin/pyhl.rs
@@ -223,6 +223,11 @@ struct SetupArgs {
     /// Repeatable: `--port 8080 --port 3000`.
     #[arg(long, value_name = "PORT")]
     port: Vec<u16>,
+
+    /// Maximum surrogate processes (Windows only). 0 disables surrogates
+    /// entirely, using VirtualAlloc + WHvMapGpaRange (single-VM-per-process).
+    #[arg(long, value_name = "N")]
+    max_surrogates: Option<u32>,
 }
 
 #[derive(Args)]
@@ -295,6 +300,11 @@ struct RunArgs {
     /// you want bit-for-bit reproducibility across calls).
     #[arg(long = "deterministic")]
     deterministic: bool,
+
+    /// Maximum surrogate processes (Windows only). 0 disables surrogates
+    /// entirely, using VirtualAlloc + WHvMapGpaRange (single-VM-per-process).
+    #[arg(long, value_name = "N")]
+    max_surrogates: Option<u32>,
 }
 
 // -- image-home resolution ----------------------------------------------------
@@ -302,7 +312,7 @@ struct RunArgs {
 const CWD_HOME: &str = ".pyhl";
 const KERNEL_FILE: &str = "kernel";
 const INITRD_FILE: &str = "initrd.cpio";
-const SNAPSHOT_FILE: &str = "snapshot.hls";
+const SNAPSHOT_DIR: &str = "snapshot";
 const VERSION_FILE: &str = "VERSION";
 
 /// Resolve the image home to use. Tries (in order): explicit, PYHL_HOME,
@@ -364,14 +374,16 @@ fn image_installed(home: &Path) -> bool {
 // -- `setup` ------------------------------------------------------------------
 
 fn cmd_setup(args: SetupArgs) -> Result<()> {
+    hyperlight_unikraft::pyhl::configure_surrogates(args.max_surrogates);
+
     let home = resolve_home(args.dest.as_deref(), ResolveMode::ForSetup)?;
 
     let dst_kernel = home.join(KERNEL_FILE);
     let dst_initrd = home.join(INITRD_FILE);
-    let dst_snapshot = home.join(SNAPSHOT_FILE);
+    let dst_snapshot = home.join(SNAPSHOT_DIR);
     let dst_version = home.join(VERSION_FILE);
 
-    if image_installed(&home) && dst_snapshot.is_file() && !args.force {
+    if image_installed(&home) && dst_snapshot.is_dir() && !args.force {
         eprintln!(
             "pyhl: image already installed at {} (use --force to overwrite)",
             home.display()
@@ -451,7 +463,7 @@ fn cmd_setup(args: SetupArgs) -> Result<()> {
     {
         let mut builder = Sandbox::builder(&dst_kernel)
             .initrd_file(&dst_initrd)
-            .heap_size(5 * 512 * 1024 * 1024);
+            .heap_size(1280 * 1024 * 1024);
         for p in &setup_preopens {
             builder = builder.preopen(p.clone());
         }
@@ -494,12 +506,7 @@ fn cmd_setup(args: SetupArgs) -> Result<()> {
         dst_initrd.display(),
         mib(&dst_initrd)
     );
-    eprintln!(
-        "  snapshot: {} ({} MiB on disk, {} MiB apparent)",
-        dst_snapshot.display(),
-        disk_mib(&dst_snapshot),
-        mib(&dst_snapshot)
-    );
+    eprintln!("  snapshot: {}", dst_snapshot.display());
     Ok(())
 }
 
@@ -507,37 +514,6 @@ fn mib(p: &Path) -> u64 {
     fs::metadata(p).map(|m| m.len() / 1024 / 1024).unwrap_or(0)
 }
 
-#[cfg(unix)]
-fn disk_mib(p: &Path) -> u64 {
-    use std::os::unix::fs::MetadataExt;
-    fs::metadata(p)
-        .map(|m| m.blocks() * 512 / 1024 / 1024)
-        .unwrap_or_else(|_| mib(p))
-}
-
-#[cfg(windows)]
-fn disk_mib(p: &Path) -> u64 {
-    use std::os::windows::ffi::OsStrExt;
-    let wide: Vec<u16> = p
-        .as_os_str()
-        .encode_wide()
-        .chain(std::iter::once(0))
-        .collect();
-    let mut high: u32 = 0;
-    let low = unsafe {
-        windows_sys::Win32::Storage::FileSystem::GetCompressedFileSizeW(wide.as_ptr(), &mut high)
-    };
-    if low == u32::MAX {
-        return mib(p);
-    }
-    let bytes = ((high as u64) << 32) | (low as u64);
-    bytes / 1024 / 1024
-}
-
-#[cfg(not(any(unix, windows)))]
-fn disk_mib(p: &Path) -> u64 {
-    mib(p)
-}
 
 /// Lightweight timestamp (seconds since epoch in ISO-8601-ish) so we don't
 /// need to pull chrono just for the VERSION stamp.
@@ -553,6 +529,8 @@ fn now_iso8601() -> String {
 // -- `run` --------------------------------------------------------------------
 
 fn cmd_run(args: RunArgs) -> Result<()> {
+    hyperlight_unikraft::pyhl::configure_surrogates(args.max_surrogates);
+
     let code = match (args.script.as_deref(), args.code.as_deref()) {
         (Some(_), Some(_)) => bail!("pass either <SCRIPT> or -c <CODE>, not both"),
         (Some(p), None) => {
@@ -563,13 +541,13 @@ fn cmd_run(args: RunArgs) -> Result<()> {
     };
 
     let home = resolve_home(args.dest.as_deref(), ResolveMode::ForRun)?;
-    let snapshot = home.join(SNAPSHOT_FILE);
+    let snapshot = home.join(SNAPSHOT_DIR);
 
     // Fast path: `pyhl setup` already warmed up a sandbox, ran
     // Py_Initialize + preloaded modules, captured the state, and
-    // persisted it to snapshot.hls. Here we mmap that file back and
+    // persisted it to snapshot/. Here we load that OCI layout back and
     // instantiate a sandbox directly — no kernel boot, no Python init.
-    if !snapshot.is_file() {
+    if !snapshot.is_dir() {
         return Err(anyhow!(
             "no warmed-up snapshot at {}.\n\
              run `pyhl setup` first (or `pyhl setup --force` if you have\n\
@@ -709,7 +687,6 @@ fn fresh_seed() -> u128 {
 // -- main ---------------------------------------------------------------------
 
 fn main() -> Result<()> {
-    hyperlight_unikraft::pyhl::default_surrogate_count();
     let cli = Cli::parse();
     match cli.cmd {
         Command::Setup(args) => cmd_setup(args),

--- a/host/src/bin/pyhl.rs
+++ b/host/src/bin/pyhl.rs
@@ -514,7 +514,6 @@ fn mib(p: &Path) -> u64 {
     fs::metadata(p).map(|m| m.len() / 1024 / 1024).unwrap_or(0)
 }
 
-
 /// Lightweight timestamp (seconds since epoch in ISO-8601-ish) so we don't
 /// need to pull chrono just for the VERSION stamp.
 fn now_iso8601() -> String {

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -2717,6 +2717,7 @@ impl Sandbox {
             .ok_or_else(|| anyhow!("no snapshot present; build() or snapshot_now() first"))?;
         let tag = OciTag::new("latest").map_err(|e| anyhow!("{e}"))?;
         snap.save(path.as_ref(), &tag).map_err(|e| anyhow!("{e}"))?;
+        sparsify_oci_blobs(path.as_ref())?;
         Ok(())
     }
 
@@ -2905,6 +2906,162 @@ pub fn run_vm_capture_output(
 // absolute paths passed in an RPC arg, and symlinks inside the mount
 // that point outside it.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// OCI blob sparsification
+// ---------------------------------------------------------------------------
+
+fn sparsify_oci_blobs(oci_dir: &Path) -> Result<()> {
+    let blobs_dir = oci_dir.join("blobs").join("sha256");
+    if !blobs_dir.is_dir() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(&blobs_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() && entry.metadata()?.len() > 1024 * 1024 {
+            sparsify_file(&path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn sparsify_file(path: &Path) -> Result<()> {
+    use std::io::Read;
+    use std::os::unix::io::AsRawFd;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+    let len = file.metadata()?.len();
+
+    const PAGE: usize = 4096;
+    let zero_page = [0u8; PAGE];
+    let mut buf = [0u8; PAGE];
+    let mut reader = std::io::BufReader::with_capacity(PAGE, &file);
+
+    let mut punched = 0u64;
+    let mut offset: u64 = 0;
+    while offset + PAGE as u64 <= len {
+        reader.read_exact(&mut buf)?;
+        if buf == zero_page {
+            let ret = unsafe {
+                libc::fallocate(
+                    file.as_raw_fd(),
+                    libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
+                    offset as i64,
+                    PAGE as i64,
+                )
+            };
+            if ret == 0 {
+                punched += 1;
+            }
+        }
+        offset += PAGE as u64;
+    }
+
+    if punched > 0 {
+        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
+        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn sparsify_file(path: &Path) -> Result<()> {
+    use std::io::Read;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::Ioctl::{FSCTL_SET_SPARSE, FSCTL_SET_ZERO_DATA};
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)?;
+    let len = file.metadata()?.len();
+    let handle = file.as_raw_handle();
+
+    let ok = unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_SET_SPARSE,
+            std::ptr::null(),
+            0,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Ok(());
+    }
+
+    const PAGE: usize = 4096;
+    let zero_page = [0u8; PAGE];
+    let mut buf = [0u8; PAGE];
+    let mut reader = std::io::BufReader::with_capacity(PAGE, &file);
+
+    let mut punched = 0u64;
+    let mut offset: u64 = 0;
+    while offset + PAGE as u64 <= len {
+        reader.read_exact(&mut buf)?;
+        if buf != zero_page {
+            offset += PAGE as u64;
+            continue;
+        }
+        let range_start = offset;
+        offset += PAGE as u64;
+        let mut range_end = offset;
+        while offset + PAGE as u64 <= len {
+            reader.read_exact(&mut buf)?;
+            offset += PAGE as u64;
+            if buf != zero_page {
+                break;
+            }
+            range_end = offset;
+        }
+
+        #[repr(C)]
+        struct FileZeroDataInformation {
+            file_offset: i64,
+            beyond_final_zero: i64,
+        }
+
+        let info = FileZeroDataInformation {
+            file_offset: range_start as i64,
+            beyond_final_zero: range_end as i64,
+        };
+        let ok = unsafe {
+            DeviceIoControl(
+                handle,
+                FSCTL_SET_ZERO_DATA,
+                &info as *const _ as *const _,
+                std::mem::size_of::<FileZeroDataInformation>() as u32,
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok != 0 {
+            punched += (range_end - range_start) / PAGE as u64;
+        }
+    }
+
+    if punched > 0 {
+        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
+        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)");
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn sparsify_file(_path: &Path) -> Result<()> {
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -60,7 +60,7 @@ pub mod stderr_capture;
 
 use anyhow::{anyhow, Result};
 use hyperlight_host::func::Registerable;
-use hyperlight_host::sandbox::snapshot::Snapshot;
+use hyperlight_host::sandbox::snapshot::{OciTag, Snapshot};
 use hyperlight_host::sandbox::uninitialized::GuestEnvironment;
 use hyperlight_host::sandbox::SandboxConfiguration;
 use hyperlight_host::{GuestBinary, HostFunctions, MultiUseSandbox, UninitializedSandbox};
@@ -2299,9 +2299,9 @@ pub struct Sandbox {
     inner: MultiUseSandbox,
     /// Post-init snapshot for fast restore between calls.
     snapshot: Option<Arc<Snapshot>>,
-    /// When set, restore uses the preserving variant to keep the
-    /// read-only file mapping alive across restores.
-    file_mapping_path: Option<std::path::PathBuf>,
+    /// Initrd path — re-mapped after every restore() since restore
+    /// overwrites the region with the snapshot's original memory.
+    initrd_path: Option<std::path::PathBuf>,
     exit_code: Arc<AtomicI32>,
     /// Shared socket table — cleared on [`Sandbox::restore`] so that
     /// host-side fds don't leak across guest restore cycles.
@@ -2578,9 +2578,12 @@ impl Sandbox {
         // from KVM_SET_USER_MEMORY_REGION on kernels where in-kernel
         // IRQCHIP reserves that range.
         const INITRD_MAP_BASE: u64 = 0xFEF0_0000;
-        if let Some(path) = initrd_path {
-            usbox.map_file_cow(path, INITRD_MAP_BASE, Some("initrd"))?;
-        }
+        let initrd_owned = if let Some(path) = initrd_path {
+            usbox.map_file_cow(path, INITRD_MAP_BASE)?;
+            Some(path.to_path_buf())
+        } else {
+            None
+        };
 
         let exit_code = Arc::new(AtomicI32::new(0));
         let sleep_cancel = SleepCancel::new();
@@ -2593,18 +2596,12 @@ impl Sandbox {
             tools_ref.dispatch(&payload)
         })?;
 
-        Self::finish_evolve(
-            usbox,
-            initrd_path.map(|p| p.to_path_buf()),
-            exit_code,
-            sleep_cancel,
-            socket_table,
-        )
+        Self::finish_evolve(usbox, initrd_owned, exit_code, sleep_cancel, socket_table)
     }
 
     fn finish_evolve(
         usbox: UninitializedSandbox,
-        file_mapping_path: Option<std::path::PathBuf>,
+        initrd_path: Option<std::path::PathBuf>,
         exit_code: Arc<AtomicI32>,
         sleep_cancel: SleepCancel,
         socket_table: Option<Arc<Mutex<SocketTable>>>,
@@ -2614,7 +2611,7 @@ impl Sandbox {
         Ok(Self {
             inner,
             snapshot,
-            file_mapping_path,
+            initrd_path,
             exit_code,
             socket_table,
             sleep_cancel,
@@ -2627,11 +2624,11 @@ impl Sandbox {
     /// guest memory to the state captured after init.
     pub fn restore(&mut self) -> Result<()> {
         if let Some(ref snap) = self.snapshot {
-            if self.file_mapping_path.is_some() {
-                self.inner.restore_preserving_file_mappings(snap.clone())?;
-            } else {
-                self.inner.restore(snap.clone())?;
-            }
+            self.inner.restore(snap.clone())?;
+        }
+        const INITRD_MAP_BASE: u64 = 0xFEF0_0000;
+        if let Some(ref path) = self.initrd_path {
+            self.inner.map_file_cow(path, INITRD_MAP_BASE)?;
         }
         if let Some(ref table) = self.socket_table {
             table.lock().unwrap().clear();
@@ -2709,19 +2706,17 @@ impl Sandbox {
         Ok(())
     }
 
-    /// Persist the current snapshot to disk as a sparse file.
+    /// Persist the current snapshot to disk in OCI image-layout format.
     ///
-    /// After writing the raw HLS snapshot, zero-filled 4 KiB pages are
-    /// punched out with `fallocate(PUNCH_HOLE)` so they consume no disk
-    /// space. The file is still mmap-loadable — holes read back as
-    /// zeros with no decompression overhead.
+    /// `path` is the directory for the OCI layout (created if absent).
+    /// The snapshot is tagged `latest`.
     pub fn save_snapshot<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         let snap = self
             .snapshot
             .as_ref()
             .ok_or_else(|| anyhow!("no snapshot present; build() or snapshot_now() first"))?;
-        snap.to_file(path.as_ref())?;
-        sparsify_snapshot(path.as_ref())?;
+        let tag = OciTag::new("latest").map_err(|e| anyhow!("{e}"))?;
+        snap.save(path.as_ref(), &tag).map_err(|e| anyhow!("{e}"))?;
         Ok(())
     }
 
@@ -2734,12 +2729,10 @@ impl Sandbox {
     /// warm-Python snapshot once, and every `pyhl run` instantiates
     /// straight from it — no kernel boot, no Py_Initialize.
     ///
-    /// Uses `Snapshot::from_file_unchecked`, which skips the SHA-256
-    /// verification over the file. We trust snapshots written by our
-    /// own `save_snapshot()` earlier in the same process family (the
-    /// pyhl install dir), and the hash verify alone costs ~500ms on
-    /// a 2.5 GB snapshot — enough to double the whole `pyhl run` wall
-    /// time on simple scripts.
+    /// Uses `Snapshot::load`, which skips SHA-256 digest verification.
+    /// We trust snapshots written by our own `save_snapshot()` in the
+    /// same install dir; checked_load costs ~500ms on a 2.5 GB
+    /// snapshot — enough to double the whole `pyhl run` wall time.
     pub fn from_snapshot_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         Self::from_snapshot_file_full(path, &[], None, None, None)
     }
@@ -2802,7 +2795,8 @@ impl Sandbox {
         network: Option<&NetworkPolicy>,
         listen_ports: Option<&ListenPorts>,
     ) -> Result<Self> {
-        let loaded = Snapshot::from_file_unchecked(path.as_ref())?;
+        let tag = OciTag::new("latest").map_err(|e| anyhow!("{e}"))?;
+        let loaded = Snapshot::load(path.as_ref(), tag).map_err(|e| anyhow!("{e}"))?;
         let arc = Arc::new(loaded);
 
         let exit_code = Arc::new(AtomicI32::new(0));
@@ -2822,13 +2816,13 @@ impl Sandbox {
 
         const INITRD_MAP_BASE: u64 = 0xFEF0_0000;
         if let Some(ref initrd_path) = initrd {
-            inner.map_file_cow(initrd_path, INITRD_MAP_BASE, Some("initrd"))?;
+            inner.map_file_cow(initrd_path, INITRD_MAP_BASE)?;
         }
 
         Ok(Self {
             inner,
             snapshot: Some(arc),
-            file_mapping_path: initrd,
+            initrd_path: initrd,
             exit_code,
             socket_table,
             sleep_cancel,
@@ -2902,152 +2896,6 @@ pub fn run_vm_capture_output(
         setup_time,
         evolve_time,
     })
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot sparsification
-// ---------------------------------------------------------------------------
-
-/// Punch holes in zero-filled 4 KiB pages of a snapshot file.
-///
-/// The HLS snapshot format is a 4 KiB header followed by a dense memory
-/// blob where ~80 % of pages are all-zeros (unused heap). Punching them
-/// with `fallocate(PUNCH_HOLE)` turns the file sparse — the zeros still
-/// read back via mmap but consume no disk blocks.
-#[cfg(target_os = "linux")]
-fn sparsify_snapshot(path: &Path) -> Result<()> {
-    use std::os::unix::io::AsRawFd;
-
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)?;
-    let len = file.metadata()?.len();
-    let mmap = unsafe { memmap2::Mmap::map(&file)? };
-
-    const PAGE: usize = 4096;
-    const HEADER: usize = PAGE;
-    let zero_page = [0u8; PAGE];
-
-    let mut punched = 0u64;
-    let mut offset = HEADER;
-    while offset + PAGE <= len as usize {
-        if mmap[offset..offset + PAGE] == zero_page {
-            let ret = unsafe {
-                libc::fallocate(
-                    file.as_raw_fd(),
-                    libc::FALLOC_FL_PUNCH_HOLE | libc::FALLOC_FL_KEEP_SIZE,
-                    offset as i64,
-                    PAGE as i64,
-                )
-            };
-            if ret == 0 {
-                punched += 1;
-            }
-        }
-        offset += PAGE;
-    }
-    drop(mmap);
-
-    if punched > 0 {
-        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
-        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
-    }
-
-    Ok(())
-}
-
-/// Windows equivalent: mark the file sparse with FSCTL_SET_SPARSE, then
-/// punch zero ranges with FSCTL_SET_ZERO_DATA.
-#[cfg(target_os = "windows")]
-fn sparsify_snapshot(path: &Path) -> Result<()> {
-    use std::os::windows::io::AsRawHandle;
-    use windows_sys::Win32::System::Ioctl::{FSCTL_SET_SPARSE, FSCTL_SET_ZERO_DATA};
-    use windows_sys::Win32::System::IO::DeviceIoControl;
-
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .open(path)?;
-    let len = file.metadata()?.len();
-    let handle = file.as_raw_handle();
-
-    // Mark file as sparse.
-    let ok = unsafe {
-        DeviceIoControl(
-            handle,
-            FSCTL_SET_SPARSE,
-            std::ptr::null(),
-            0,
-            std::ptr::null_mut(),
-            0,
-            std::ptr::null_mut(),
-            std::ptr::null_mut(),
-        )
-    };
-    if ok == 0 {
-        return Ok(());
-    }
-
-    let mmap = unsafe { memmap2::Mmap::map(&file)? };
-
-    const PAGE: usize = 4096;
-    const HEADER: usize = PAGE;
-    let zero_page = [0u8; PAGE];
-
-    // Coalesce contiguous zero pages into ranges for fewer syscalls.
-    let mut punched = 0u64;
-    let mut offset = HEADER;
-    while offset + PAGE <= len as usize {
-        if mmap[offset..offset + PAGE] != zero_page {
-            offset += PAGE;
-            continue;
-        }
-        let range_start = offset;
-        while offset + PAGE <= len as usize && mmap[offset..offset + PAGE] == zero_page {
-            offset += PAGE;
-        }
-        let range_end = offset;
-
-        #[repr(C)]
-        struct FileZeroDataInformation {
-            file_offset: i64,
-            beyond_final_zero: i64,
-        }
-
-        let info = FileZeroDataInformation {
-            file_offset: range_start as i64,
-            beyond_final_zero: range_end as i64,
-        };
-        let ok = unsafe {
-            DeviceIoControl(
-                handle,
-                FSCTL_SET_ZERO_DATA,
-                &info as *const _ as *const _,
-                std::mem::size_of::<FileZeroDataInformation>() as u32,
-                std::ptr::null_mut(),
-                0,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
-            )
-        };
-        if ok != 0 {
-            punched += (range_end - range_start) as u64 / PAGE as u64;
-        }
-    }
-    drop(mmap);
-
-    if punched > 0 {
-        let disk_mib = (len - punched * PAGE as u64) / 1024 / 1024;
-        eprintln!("  sparsified: {disk_mib} MiB on disk (punched {punched} zero pages)",);
-    }
-
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "linux", target_os = "windows")))]
-fn sparsify_snapshot(_path: &Path) -> Result<()> {
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/host/src/pyhl.rs
+++ b/host/src/pyhl.rs
@@ -4,7 +4,7 @@
 //! Two pieces:
 //!
 //! - [`install`] — one-time: take a source image (or a GHCR pull) and
-//!   materialize `kernel`, `initrd.cpio`, and a warmed-up `snapshot.hls`
+//!   materialize `kernel`, `initrd.cpio`, and a warmed-up `snapshot/`
 //!   in the image home.
 //!
 //! - [`Runtime`] — the steady-state object: holds an open
@@ -32,7 +32,7 @@
 //!     force: false,
 //! })?;
 //!
-//! let mut rt = pyhl::Runtime::new(home, &[Preopen::new("./share", "/host")?], None, None)?;
+//! let mut rt = pyhl::Runtime::new(home, &[Preopen::new("./share", "/host")?], None, None, None)?;
 //! rt.run_code("print('hello from rust')")?;
 //! rt.run_code("print('hermetic second call')")?;  // fresh __main__ each time
 //! # Ok(())
@@ -49,30 +49,51 @@ use std::time::Instant;
 
 use crate::{Preopen, Sandbox};
 
-/// Set `HYPERLIGHT_INITIAL_SURROGATES=1` if unset (Windows only).
+/// Configure surrogate process count (Windows only).
 ///
 /// On Windows, Hyperlight pre-spawns surrogate processes (one per
 /// potential sandbox). The default count is 512, each costing ~7 ms
-/// of `CreateProcessA` latency. For pyhl's single-sandbox usage,
-/// pinning to 1 avoids ~3.5 s of wasted startup.
+/// of `CreateProcessA` latency.
+///
+/// When `max_surrogates` is `Some(0)`, surrogates are fully disabled:
+/// the host uses `VirtualAlloc` + `WHvMapGpaRange` directly
+/// (single-VM-per-process mode).
+///
+/// When `max_surrogates` is `None`, defaults to 1 (suitable for
+/// pyhl's single-sandbox usage, avoids ~3.5 s of wasted startup).
 ///
 /// # Safety
 ///
 /// Must be called from the main thread before spawning any additional
 /// threads or creating any `Sandbox`. Violating this is undefined
 /// behavior due to `std::env::set_var` not being thread-safe.
-pub fn default_surrogate_count() {
+pub fn configure_surrogates(max_surrogates: Option<u32>) {
     #[cfg(target_os = "windows")]
     {
-        if std::env::var_os("HYPERLIGHT_INITIAL_SURROGATES").is_none() {
-            // SAFETY: Called from main thread before any sandbox or
-            // thread pool is created. The binary entry points (cmd_run,
-            // cmd_setup) call this first.
-            unsafe {
-                std::env::set_var("HYPERLIGHT_INITIAL_SURROGATES", "1");
+        // SAFETY: Called from main thread before any sandbox or
+        // thread pool is created. The binary entry points (cmd_run,
+        // cmd_setup) call this first.
+        unsafe {
+            match max_surrogates {
+                Some(n) => {
+                    std::env::set_var("HYPERLIGHT_MAX_SURROGATES", n.to_string());
+                    std::env::set_var("HYPERLIGHT_INITIAL_SURROGATES", n.to_string());
+                }
+                None => {
+                    if std::env::var_os("HYPERLIGHT_INITIAL_SURROGATES").is_none() {
+                        std::env::set_var("HYPERLIGHT_INITIAL_SURROGATES", "1");
+                    }
+                }
             }
         }
     }
+    #[cfg(not(target_os = "windows"))]
+    let _ = max_surrogates;
+}
+
+/// Deprecated: use [`configure_surrogates`] instead.
+pub fn default_surrogate_count() {
+    configure_surrogates(None);
 }
 
 /// Standard file names inside an image home.
@@ -80,14 +101,14 @@ pub const KERNEL_FILE: &str = "kernel";
 /// Standard file names inside an image home.
 pub const INITRD_FILE: &str = "initrd.cpio";
 /// Standard file names inside an image home.
-pub const SNAPSHOT_FILE: &str = "snapshot.hls";
+pub const SNAPSHOT_DIR: &str = "snapshot";
 /// Standard file names inside an image home.
 pub const VERSION_FILE: &str = "VERSION";
 
 /// Configuration for [`install`].
 pub struct InstallOptions<'a> {
     /// Target directory. Files are written at
-    /// `{home}/{kernel,initrd.cpio,snapshot.hls,VERSION}`.
+    /// `{home}/{kernel,initrd.cpio,snapshot/,VERSION}`.
     pub home: &'a Path,
 
     /// Where to get the image from.
@@ -105,6 +126,11 @@ pub struct InstallOptions<'a> {
     /// Ports the guest may bind to for inbound connections.
     /// `None` means outbound-only (when networking is enabled).
     pub listen_ports: Option<&'a crate::ListenPorts>,
+
+    /// Maximum surrogate processes on Windows. `Some(0)` disables
+    /// surrogates entirely (single-VM-per-process). `None` uses the
+    /// default (1 for pyhl).
+    pub max_surrogates: Option<u32>,
 
     /// Overwrite an existing install.
     pub force: bool,
@@ -142,14 +168,14 @@ pub struct InstallReport {
 /// are local file copies. See [`InstallSource`] for each variant's
 /// semantics.
 pub fn install(opts: &InstallOptions<'_>) -> Result<InstallReport> {
-    default_surrogate_count();
+    configure_surrogates(opts.max_surrogates);
     let home = opts.home.to_path_buf();
     let dst_kernel = home.join(KERNEL_FILE);
     let dst_initrd = home.join(INITRD_FILE);
-    let dst_snapshot = home.join(SNAPSHOT_FILE);
+    let dst_snapshot = home.join(SNAPSHOT_DIR);
     let dst_version = home.join(VERSION_FILE);
 
-    let already = dst_kernel.is_file() && dst_initrd.is_file() && dst_snapshot.is_file();
+    let already = dst_kernel.is_file() && dst_initrd.is_file() && dst_snapshot.is_dir();
     if already && !opts.force {
         return Ok(InstallReport {
             home,
@@ -197,7 +223,7 @@ pub fn install(opts: &InstallOptions<'_>) -> Result<InstallReport> {
     {
         let mut builder = Sandbox::builder(&dst_kernel)
             .initrd_file(&dst_initrd)
-            .heap_size(5 * 512 * 1024 * 1024);
+            .heap_size(1280 * 1024 * 1024);
         for p in opts.mounts {
             builder = builder.preopen(p.clone());
         }
@@ -255,20 +281,23 @@ pub struct Runtime {
 
 impl Runtime {
     /// Open a runtime against an existing install. Looks for
-    /// `{home}/snapshot.hls` and mmap-loads it. `mounts` specify host
+    /// `{home}/snapshot/` and mmap-loads it. `mounts` specify host
     /// directories to expose under the guest paths that were baked in
     /// at `install` time. `network` enables guest networking with the
     /// given policy (`None` = disabled). `listen_ports` controls which
     /// ports the guest may bind to (`None` = outbound-only).
+    /// `max_surrogates` controls surrogate process count on Windows
+    /// (`Some(0)` disables them entirely, `None` defaults to 1).
     pub fn new(
         home: &Path,
         mounts: &[Preopen],
         network: Option<&crate::NetworkPolicy>,
         listen_ports: Option<&crate::ListenPorts>,
+        max_surrogates: Option<u32>,
     ) -> Result<Self> {
-        default_surrogate_count();
-        let snap = home.join(SNAPSHOT_FILE);
-        if !snap.is_file() {
+        configure_surrogates(max_surrogates);
+        let snap = home.join(SNAPSHOT_DIR);
+        if !snap.is_dir() {
             bail!(
                 "no snapshot at {} — run pyhl::install first",
                 snap.display()

--- a/host/src/pyhl.rs
+++ b/host/src/pyhl.rs
@@ -175,7 +175,8 @@ pub fn install(opts: &InstallOptions<'_>) -> Result<InstallReport> {
     let dst_snapshot = home.join(SNAPSHOT_DIR);
     let dst_version = home.join(VERSION_FILE);
 
-    let already = dst_kernel.is_file() && dst_initrd.is_file() && dst_snapshot.is_dir();
+    let already =
+        dst_kernel.is_file() && dst_initrd.is_file() && dst_snapshot.join("index.json").is_file();
     if already && !opts.force {
         return Ok(InstallReport {
             home,
@@ -297,7 +298,7 @@ impl Runtime {
     ) -> Result<Self> {
         configure_surrogates(max_surrogates);
         let snap = home.join(SNAPSHOT_DIR);
-        if !snap.is_dir() {
+        if !snap.join("index.json").is_file() {
             bail!(
                 "no snapshot at {} — run pyhl::install first",
                 snap.display()

--- a/host/tests/pyhl_runtime.rs
+++ b/host/tests/pyhl_runtime.rs
@@ -5,7 +5,7 @@
 //! (filesystem mounts, network policies, exit codes, hermetic rewinds).
 //!
 //! All tests self-skip if the pyhl image is not installed (no snapshot at
-//! `.pyhl/snapshot`) or if no hypervisor is available. Run `pyhl setup`
+//! `.pyhl/snapshot/`) or if no hypervisor is available. Run `pyhl setup`
 //! to populate the image before running these tests.
 
 use hyperlight_unikraft::pyhl::Runtime;
@@ -37,12 +37,12 @@ fn pyhl_home() -> Option<PathBuf> {
         .parent()
         .unwrap()
         .join(".pyhl");
-    if workspace.join("snapshot").is_dir() {
+    if workspace.join("snapshot").join("index.json").is_file() {
         return Some(workspace);
     }
     // Check user-level install
     if let Some(home) = dirs_or_default() {
-        if home.join("snapshot").is_dir() {
+        if home.join("snapshot").join("index.json").is_file() {
             return Some(home);
         }
     }

--- a/host/tests/pyhl_runtime.rs
+++ b/host/tests/pyhl_runtime.rs
@@ -5,7 +5,7 @@
 //! (filesystem mounts, network policies, exit codes, hermetic rewinds).
 //!
 //! All tests self-skip if the pyhl image is not installed (no snapshot at
-//! `.pyhl/snapshot.hls`) or if no hypervisor is available. Run `pyhl setup`
+//! `.pyhl/snapshot`) or if no hypervisor is available. Run `pyhl setup`
 //! to populate the image before running these tests.
 
 use hyperlight_unikraft::pyhl::Runtime;
@@ -37,12 +37,12 @@ fn pyhl_home() -> Option<PathBuf> {
         .parent()
         .unwrap()
         .join(".pyhl");
-    if workspace.join("snapshot.hls").is_file() {
+    if workspace.join("snapshot").is_dir() {
         return Some(workspace);
     }
     // Check user-level install
     if let Some(home) = dirs_or_default() {
-        if home.join("snapshot.hls").is_file() {
+        if home.join("snapshot").is_dir() {
             return Some(home);
         }
     }
@@ -71,7 +71,7 @@ fn setup() -> Option<(PathBuf, Runtime)> {
         return None;
     }
     let home = pyhl_home()?;
-    let rt = Runtime::new(&home, &[], None, None).ok()?;
+    let rt = Runtime::new(&home, &[], None, None, None).ok()?;
     Some((home, rt))
 }
 
@@ -81,7 +81,7 @@ fn setup_with_net(policy: NetworkPolicy) -> Option<Runtime> {
         return None;
     }
     let home = pyhl_home()?;
-    Runtime::new(&home, &[], Some(&policy), None).ok()
+    Runtime::new(&home, &[], Some(&policy), None, None).ok()
 }
 
 fn setup_with_mount(preopen: Preopen) -> Option<Runtime> {
@@ -90,7 +90,7 @@ fn setup_with_mount(preopen: Preopen) -> Option<Runtime> {
         return None;
     }
     let home = pyhl_home()?;
-    Runtime::new(&home, &[preopen], None, None).ok()
+    Runtime::new(&home, &[preopen], None, None, None).ok()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Switch hyperlight-host dependency from a git pin on `danbugs/hyperlight` to `hyperlight-host = "0.16.0"` from crates.io. This unblocks publishing hyperlight-unikraft to crates.io (closes #4, unblocks #27).

Key changes:
- **OCI snapshot format**: `to_file`/`from_file_unchecked` → `save`/`load` with OCI image-layout. Snapshot path changes from `snapshot.hls` (file) to `snapshot/` (directory)
- **map_file_cow**: 3-arg → 2-arg (label parameter removed upstream)
- **restore**: `restore_preserving_file_mappings` removed; initrd is re-mapped after every `restore()`
- **Sparsify removed**: OCI format manages storage; `sparsify_snapshot` and related platform-specific code dropped
- **whp-no-surrogate feature removed**: now controlled via `HYPERLIGHT_MAX_SURROGATES` env var at runtime
- **max_surrogates API**: `configure_surrogates()`, `InstallOptions.max_surrogates`, and `Runtime::new()` 5th arg for mxc integration
- **Heap size**: reduced default from 2560 MiB to 1280 MiB

## Test plan

- [x] `cargo check` / `cargo clippy` pass
- [x] CI passes (runtime tests, benchmarks)
- [ ] mxc compiles with this branch