### PR TITLE
perf: enable demand paging for heap (3 GiB → 654 MiB snapshots)

### DIFF
--- a/examples/dotnet-http/kraft.yaml
+++ b/examples/dotnet-http/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: dotnet-http-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/dotnet-nativeaot/kraft.yaml
+++ b/examples/dotnet-nativeaot/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: dotnet-nativeaot-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'

--- a/examples/dotnet/kraft.yaml
+++ b/examples/dotnet/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: dotnet-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/go-http/kraft.yaml
+++ b/examples/go-http/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: go-http-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/go/kraft.yaml
+++ b/examples/go/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: go-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/helloworld-c/kraft.yaml
+++ b/examples/helloworld-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: helloworld-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'

--- a/examples/hostfs-posix-c/kraft.yaml
+++ b/examples/hostfs-posix-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: hostfs-posix-c-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/hostfs-posix-py/kraft.yaml
+++ b/examples/hostfs-posix-py/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: hostfs-posix-py-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/multifn-c/kraft.yaml
+++ b/examples/multifn-c/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: multifn-c-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'

--- a/examples/networking-py/kraft.yaml
+++ b/examples/networking-py/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: networking-py-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/nodejs/kraft.yaml
+++ b/examples/nodejs/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: nodejs-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/powershell/kraft.yaml
+++ b/examples/powershell/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: powershell-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/python-agent-driver/kraft.yaml
+++ b/examples/python-agent-driver/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: python-agent-driver-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     CONFIG_PLAT_HYPERLIGHT: 'y'
     CONFIG_PAGING: 'n'

--- a/examples/python-agent/kraft.yaml
+++ b/examples/python-agent/kraft.yaml
@@ -2,8 +2,8 @@ specification: '0.6'
 name: python-agent-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/python-tools/kraft.yaml
+++ b/examples/python-tools/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: python-tools-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/python/kraft.yaml
+++ b/examples/python/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: python-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/rust/kraft.yaml
+++ b/examples/rust/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: rust-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'

--- a/examples/shell/kraft.yaml
+++ b/examples/shell/kraft.yaml
@@ -3,8 +3,8 @@ specification: '0.6'
 name: shell-hyperlight
 
 unikraft:
-  source: https://github.com/unikraft/unikraft.git
-  version: plat-hyperlight
+  source: https://github.com/danbugs/unikraft.git
+  version: perf/demand-page-heap
   kconfig:
     # Platform
     CONFIG_PLAT_HYPERLIGHT: 'y'


### PR DESCRIPTION
## Summary

- Points all examples at `danbugs/unikraft:perf/demand-page-heap`, which adds a `uk_paging_page_unmap` call in `boot.c:heap_init()` to tear down boot-provided identity-mapped PTEs after setting up the demand-paged VMA
- Hyperlight's `Snapshot::from_env()` identity-maps the entire heap in boot page tables before the guest starts. Unikraft's `uk_vma_map_anon` creates a demand-paged VMA on top but never removes the existing PTEs, so `vma_op_anon_fault` never fires and all heap pages (including untouched zeroes) end up in the snapshot
- The fix unmaps the boot PTEs for the heap remainder (keeping 16 bootstrap pages), letting the VMA fault handler re-map pages on first access — only touched pages carry PTEs
- Python snapshot shrinks from 3.0 GiB to 654 MiB (1 zero page remaining vs ~600K before)

## Test plan

- [ ] CI passes for all 18 examples with the fork branch
- [ ] Validate snapshot sizes are reduced for Python guests