### PR TITLE
test: expand local example smoke coverage

### DIFF
--- a/scripts/test-examples.ps1
+++ b/scripts/test-examples.ps1
@@ -1,6 +1,6 @@
-# Run one example per language to verify the build+run pipeline.
-# Languages: C, Rust, Go, .NET, PowerShell, Shell, Python
-#
+# Run representative finite examples to verify the build+run pipeline.
+# Covers C, Rust, Go, .NET, PowerShell, Shell, Python, Node.js, hostfs, and Wasm host tools.
+
 # Usage: .\scripts\test-examples.ps1
 
 $ErrorActionPreference = "Continue"
@@ -72,9 +72,15 @@ Run-Example "helloworld-c"
 Run-Example "rust"
 Run-Example "go"
 Run-Example "dotnet"
+Run-Example "dotnet-nativeaot"
 Run-Example "powershell"
 Run-Example "shell"
 Run-Example "python"
+Run-Example "python-tools"
+Run-Example "nodejs"
+Run-Example "hostfs-posix-c"
+Run-Example "hostfs-posix-py"
+Run-Example "python-agent"
 
 Write-Host ""
 if ($Failures -gt 0) {

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Run one example per language to verify the build+run pipeline.
-# Languages: C, Rust, Go, .NET, PowerShell, Shell, Python
-#
+# Run representative finite examples to verify the build+run pipeline.
+# Covers C, Rust, Go, .NET, PowerShell, Shell, Python, Node.js, hostfs, and Wasm host tools.
+
 # Usage: ./scripts/test-examples.sh
 
 set -uo pipefail
@@ -89,9 +89,15 @@ run_example "helloworld-c"
 run_example "rust"
 run_example "go"
 run_example "dotnet"
+run_example "dotnet-nativeaot"
 run_example "powershell"
 run_example "shell"
 run_example "python"
+run_example "python-tools"
+run_example "nodejs"
+run_example "hostfs-posix-c"
+run_example "hostfs-posix-py"
+run_example "python-agent"
 
 echo ""
 if [ "$FAILURES" -gt 0 ]; then


### PR DESCRIPTION
Something I forgot from #91 was to expand the local example smoke-test scripts to cover the Wasm host tools path via `python-tools`. 

I also went ahead and added more finite examples that were not included:

- dotnet-nativeaot
- python-tools
- nodejs
- hostfs-posix-c
- hostfs-posix-py
- python-agent

