### PR TITLE
release: v0.11.0 — first crates.io publish

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,6 +1,8 @@
 name: Publish to crates.io
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -16,8 +18,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
-    if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.dry_run }}
-
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,8 +25,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Determine if dry run
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Verify version matches tag
-        if: ${{ !inputs.dry_run }}
+        if: ${{ steps.mode.outputs.dry_run == 'false' }}
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
           CARGO_VER=$(grep '^version' host/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
@@ -38,18 +47,22 @@ jobs:
       - name: Check crate not already published
         run: |
           CARGO_VER=$(grep '^version' host/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          if curl -sf "https://crates.io/api/v1/crates/hyperlight-unikraft-host/$CARGO_VER" | jq -e .version > /dev/null 2>&1; then
+          if curl -sf "https://crates.io/api/v1/crates/hyperlight-unikraft-host/$CARGO_VER" -H "User-Agent: hyperlight-unikraft" | jq -e .version > /dev/null 2>&1; then
             echo "::warning::hyperlight-unikraft-host@$CARGO_VER already published"
             echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
           fi
 
+      - name: Dry run (no auth needed)
+        if: ${{ steps.mode.outputs.dry_run == 'true' && env.ALREADY_PUBLISHED != 'true' }}
+        run: cargo publish --manifest-path host/Cargo.toml --dry-run
+
       - name: Authenticate with crates.io
-        if: ${{ env.ALREADY_PUBLISHED != 'true' }}
+        if: ${{ steps.mode.outputs.dry_run == 'false' && env.ALREADY_PUBLISHED != 'true' }}
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
 
       - name: Publish hyperlight-unikraft-host
-        if: ${{ env.ALREADY_PUBLISHED != 'true' }}
-        run: cargo publish --manifest-path host/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        if: ${{ steps.mode.outputs.dry_run == 'false' && env.ALREADY_PUBLISHED != 'true' }}
+        run: cargo publish --manifest-path host/Cargo.toml
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,0 +1,55 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without actually publishing"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    if: ${{ startsWith(github.ref, 'refs/tags/v') || inputs.dry_run }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches tag
+        if: ${{ !inputs.dry_run }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          CARGO_VER=$(grep '^version' host/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TAG" != "$CARGO_VER" ]; then
+            echo "::error::Tag v$TAG does not match Cargo.toml version $CARGO_VER"
+            exit 1
+          fi
+
+      - name: Check crate not already published
+        run: |
+          CARGO_VER=$(grep '^version' host/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          if curl -sf "https://crates.io/api/v1/crates/hyperlight-unikraft-host/$CARGO_VER" | jq -e .version > /dev/null 2>&1; then
+            echo "::warning::hyperlight-unikraft-host@$CARGO_VER already published"
+            echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Authenticate with crates.io
+        if: ${{ env.ALREADY_PUBLISHED != 'true' }}
+        uses: rust-lang/crates-io-auth-action@v1
+        id: crates-io-auth
+
+      - name: Publish hyperlight-unikraft-host
+        if: ${{ env.ALREADY_PUBLISHED != 'true' }}
+        run: cargo publish --manifest-path host/Cargo.toml ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Check crate not already published
         run: |
           CARGO_VER=$(grep '^version' host/Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-          if curl -sf "https://crates.io/api/v1/crates/hyperlight-unikraft-host/$CARGO_VER" -H "User-Agent: hyperlight-unikraft" | jq -e .version > /dev/null 2>&1; then
-            echo "::warning::hyperlight-unikraft-host@$CARGO_VER already published"
+          if curl -sf "https://crates.io/api/v1/crates/hyperlight-unikraft/$CARGO_VER" -H "User-Agent: hyperlight-unikraft" | jq -e .version > /dev/null 2>&1; then
+            echo "::warning::hyperlight-unikraft@$CARGO_VER already published"
             echo "ALREADY_PUBLISHED=true" >> "$GITHUB_ENV"
           fi
 
@@ -61,7 +61,7 @@ jobs:
         uses: rust-lang/crates-io-auth-action@v1
         id: crates-io-auth
 
-      - name: Publish hyperlight-unikraft-host
+      - name: Publish hyperlight-unikraft
         if: ${{ steps.mode.outputs.dry_run == 'false' && env.ALREADY_PUBLISHED != 'true' }}
         run: cargo publish --manifest-path host/Cargo.toml
         env:

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pillow/lxml/cryptography/dateutil/dotenv preloaded) behind a simple
 
 ```bash
 # Install pyhl from crates.io
-cargo install hyperlight-unikraft-host --bin pyhl
+cargo install hyperlight-unikraft --bin pyhl
 
 # One-time: build the driver image (kernel + CPIO)
 cd examples/python-agent-driver

--- a/README.md
+++ b/README.md
@@ -117,14 +117,13 @@ pillow/lxml/cryptography/dateutil/dotenv preloaded) behind a simple
 `setup` / `run` workflow:
 
 ```bash
+# Install pyhl from crates.io
+cargo install hyperlight-unikraft-host --bin pyhl
+
 # One-time: build the driver image (kernel + CPIO)
 cd examples/python-agent-driver
 just rootfs && just build
 cd ../..
-
-# Install pyhl
-cargo install --git https://github.com/hyperlight-dev/hyperlight-unikraft \
-    hyperlight-unikraft-host --bin pyhl
 
 # Point pyhl at the image you just built — creates ./.pyhl/ in cwd
 pyhl setup --from examples/python-agent-driver

--- a/demos/pptx-gen/Cargo.toml
+++ b/demos/pptx-gen/Cargo.toml
@@ -6,7 +6,7 @@ description = "PowerPoint generator using Hyperlight-Unikraft sandboxed Python e
 
 [dependencies]
 # Hyperlight-Unikraft library
-hyperlight-unikraft = { path = "../../host", package = "hyperlight-unikraft-host" }
+hyperlight-unikraft = { path = "../../host" }
 
 # OpenAI API client
 async-openai = "0.25"

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "hyperlight-unikraft-host"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/host/Cargo.lock
+++ b/host/Cargo.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlight-unikraft-host"
+name = "hyperlight-unikraft"
 version = "0.11.0"
 dependencies = [
  "anyhow",

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "hyperlight-unikraft-host"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"
 license = "MIT OR Apache-2.0"
+repository = "https://github.com/hyperlight-dev/hyperlight-unikraft"
+homepage = "https://github.com/hyperlight-dev/hyperlight-unikraft"
+keywords = ["hyperlight", "unikraft", "unikernel", "microvm", "sandbox"]
+categories = ["virtualization"]
+readme = "../README.md"
 
 [lib]
 name = "hyperlight_unikraft"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hyperlight-unikraft-host"
+name = "hyperlight-unikraft"
 version = "0.11.0"
 edition = "2021"
 description = "Embedded Hyperlight host for running Unikraft unikernels"


### PR DESCRIPTION
## Summary

Prepares hyperlight-unikraft-host v0.11.0 for publishing to crates.io (closes #27).

- Version bump 0.10.0 → 0.11.0
- Add crates.io metadata (repository, homepage, keywords, categories, readme)
- Add `cargo-publish.yml` workflow (workflow_dispatch, trusted publishing via `crates-io-auth-action`)
- Update README: `cargo install hyperlight-unikraft-host --bin pyhl` as the primary install path

## Test plan

- [x] `cargo publish --dry-run` passes
- [ ] CI passes
- [ ] After merge: tag `v0.11.0`, trigger publish workflow with `dry_run: false`