### PR TITLE
ci: trigger cargo publish from release workflow

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -1,8 +1,6 @@
 name: Publish to crates.io
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           gh workflow run publish-examples.yml --ref "v$VERSION"
+
+      - name: Trigger crates.io publish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          gh workflow run cargo-publish.yml --ref "v$VERSION" -f dry_run=false


### PR DESCRIPTION
## Summary

- Add `cargo-publish.yml` dispatch to `release.yml` (same pattern as GHCR image publish)
- Remove dead `on: release` trigger from `cargo-publish.yml` — releases created by `GITHUB_TOKEN` don't fire `on: release` events

## Test plan

- [x] Verified manually: v0.11.0 required manual `workflow_dispatch` to publish to crates.io
- [ ] CI passes