### PR TITLE
test: verify urllib GET without timeout fails on main kernel

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -224,6 +224,9 @@ jobs:
             args: "--net -- /urllib_get.py"
             expect: "SUCCESS: urllib GET worked!"
           - example: networking-py
+            args: "--net -- /urllib_get_no_timeout.py"
+            expect: "SUCCESS: urllib GET \\(no timeout\\) worked!"
+          - example: networking-py
             args: "--port 8080 -- /echo_server_test.py"
             expect: "SUCCESS: bind\\+listen on port 8080 allowed"
           - example: go-http
@@ -613,6 +616,9 @@ jobs:
           - example: networking-py
             args: "--net -- /urllib_get.py"
             expect: "SUCCESS: urllib GET worked!"
+          - example: networking-py
+            args: "--net -- /urllib_get_no_timeout.py"
+            expect: "SUCCESS: urllib GET \\(no timeout\\) worked!"
           - example: networking-py
             args: "--port 8080 -- /echo_server_test.py"
             expect: "SUCCESS: bind\\+listen on port 8080 allowed"

--- a/examples/networking-py/Dockerfile
+++ b/examples/networking-py/Dockerfile
@@ -8,6 +8,7 @@ FROM ${BASE} AS rootfs
 COPY http_get.py /http_get.py
 COPY echo_server.py /echo_server.py
 COPY urllib_get.py /urllib_get.py
+COPY urllib_get_no_timeout.py /urllib_get_no_timeout.py
 COPY https_test.py /https_test.py
 COPY echo_server_test.py /echo_server_test.py
 

--- a/examples/networking-py/urllib_get_no_timeout.py
+++ b/examples/networking-py/urllib_get_no_timeout.py
@@ -1,0 +1,25 @@
+"""HTTP GET using urllib WITHOUT an explicit timeout.
+
+Same as urllib_get.py but omits the timeout= argument to urlopen().
+This exercises the code path used by mxc, where the Unikraft guest
+kernel relies on the idle thread's halt_irq callback to poll sockets
+via __hl_sleep rather than an explicit timeout-driven poll cycle.
+"""
+import urllib.request
+import sys
+
+URL = "http://example.com/"
+
+print(f"Fetching {URL} (no timeout) ...")
+try:
+    with urllib.request.urlopen(URL) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        print(f"Status: {resp.status}")
+        print(f"Body length: {len(body)} bytes")
+        if "Example Domain" in body:
+            print("SUCCESS: urllib GET (no timeout) worked!")
+        else:
+            print("WARNING: unexpected body content")
+except Exception as e:
+    print(f"FAILED: {e}")
+    sys.exit(1)


### PR DESCRIPTION
Adds the same `urllib_get_no_timeout.py` test from #106 but against main's kernel (no idle-poll fix). Expected to fail — verifies the regression exists on main.

**Do not merge** — verification-only branch, will be closed after CI runs.