### PR TITLE
chore(examples): Fix hypervisor annotation and use bunny

### DIFF
--- a/examples/helloworld-c/Justfile
+++ b/examples/helloworld-c/Justfile
@@ -46,9 +46,9 @@ build:
     docker cp {{image}}-kernel-tmp:/kernel ./{{kernel}}
     docker rm -f {{image}}-kernel-tmp
 
-# Build urunc-compatible OCI image (requires kernel to be built first)
-urunc-image: build
-    docker build --platform linux/amd64 -f urunc.Dockerfile -t hello-hyperlight-unikraft:latest .
+# Build urunc-compatible OCI image
+urunc-image:
+    DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -f urunc.Dockerfile -t hello-hyperlight-unikraft:latest .
 
 # Clean + rebuild everything
 rebuild: clean build rootfs

--- a/examples/helloworld-c/urunc.Dockerfile
+++ b/examples/helloworld-c/urunc.Dockerfile
@@ -1,3 +1,4 @@
+#syntax=harbor.nbfc.io/nubificus/bunny:latest
 FROM alpine:3.20 AS build
 RUN apk add --no-cache musl-dev gcc cpio findutils
 COPY hello.c /src/hello.c
@@ -5,11 +6,12 @@ RUN gcc -static-pie -fPIE -fno-stack-protector -o /src/hello /src/hello.c
 RUN mkdir -p /rootfs/bin && cp /src/hello /rootfs/bin/hello \
     && cd /rootfs && find . | cpio -o -H newc > /output.cpio 2>/dev/null
 
+FROM ghcr.io/hyperlight-dev/hyperlight-unikraft/helloworld-c-kernel:latest AS kernel
+
 FROM scratch
-COPY .unikraft/build/helloworld-hyperlight_hyperlight-x86_64 /unikernel/kernel
 COPY --from=build /output.cpio /unikernel/initrd.cpio
-COPY urunc.json /urunc.json
+COPY --from=kernel /kernel /unikernel/kernel
 LABEL "com.urunc.unikernel.unikernelType"="unikraft"
-LABEL "com.urunc.unikernel.hypervisor"="hyperlight"
+LABEL "com.urunc.unikernel.hypervisor"="hyperlight-unikraft"
 LABEL "com.urunc.unikernel.binary"="/unikernel/kernel"
 LABEL "com.urunc.unikernel.initrd"="/unikernel/initrd.cpio"

--- a/examples/helloworld-c/urunc.json
+++ b/examples/helloworld-c/urunc.json
@@ -1,6 +1,0 @@
-{
-  "com.urunc.unikernel.unikernelType": "dW5pa3JhZnQ=",
-  "com.urunc.unikernel.hypervisor": "aHlwZXJsaWdodA==",
-  "com.urunc.unikernel.binary": "L3VuaWtlcm5lbC9rZXJuZWw=",
-  "com.urunc.unikernel.initrd": "L3VuaWtlcm5lbC9pbml0cmQuY3Bpbw=="
-}


### PR DESCRIPTION
Update the urunc.Dockerfile, since the "hypervisor" name of "hyperlight" was changed to "hyperlight-unikraft".

Also, replace the "urunc.json" file with direct use of [bunny](https://github.com/nubificus/bunny). However bunny requires `DOCKER_BUILDKIT=1`. Not really sure why is set to 0, but if buildkit must remain disabled, I will bring back the "urunc.json" file. 

Fixes https://github.com/hyperlight-dev/hyperlight-unikraft/issues/112

